### PR TITLE
Remove trust info

### DIFF
--- a/5KPlayer/5KPlayer.filewave.recipe
+++ b/5KPlayer/5KPlayer.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.5KPlayer</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.5KPlayer</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/5KPlayer/5KPlayer.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>881a260810973aeaf4c89c2a5c5e98161fa3dda03c2312234c6fde658002f061</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ADPassMon/ADPassMon.filewave.recipe
+++ b/ADPassMon/ADPassMon.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.ADPassMon</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.ADPassMon</key>
-			<dict>
-				<key>git_hash</key>
-				<string>56d469b1b1a1157b994fdae4ab2f0e7c161f434d</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/ADPassMon/ADPassMon.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>b4a45f25ee910f627c337f487e12b9c1d85c57776498b3952dce3ecc559521f3</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Adobe/AdobeCreativeCloudInstaller.filewave.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller.filewave.recipe
@@ -17,32 +17,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.pkg.AdobeCreativeCloudInstaller</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.rtrouton.download.AdobeCreativeCloudInstaller</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8e5f1e080f2bf3ecc4749634071d8c15455ddc0a</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>1644b0333520bfc73cc93b90f2e8ac0437649c23e043ea6c3f27c1df9a42d7e8</string>
-			</dict>
-			<key>com.github.rtrouton.pkg.AdobeCreativeCloudInstaller</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8e5f1e080f2bf3ecc4749634071d8c15455ddc0a</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstaller.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>7a24313948e63e23090f584d3baac5e448a9155869781d7cf0c482b9d34390e9</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Alfred3/Alfred3.filewave.recipe
+++ b/Alfred3/Alfred3.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Alfred3</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>AlfredURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>7ecc2f0d28ff36d67aee66851531caff2377f7b3</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/AlfredApp/AlfredURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>eb8e3bc04d7e7b206af744c4c08206590b2d5a3b42e2670dcc849d8386133f55</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.Alfred3</key>
-			<dict>
-				<key>git_hash</key>
-				<string>7ecc2f0d28ff36d67aee66851531caff2377f7b3</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/AlfredApp/Alfred3.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>e21d209f245e1ac975003fa5fe34266074b4f52fcf2bf66a3651336bb08981bb</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AppCleaner/AppCleaner.filewave.recipe
+++ b/AppCleaner/AppCleaner.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jleggat.AppCleaner.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jleggat.AppCleaner.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>55371b0cb7d3a9528691e0e94e999674900fdabd</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes/AppCleaner/AppCleaner.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>8cfac1d88c333c08f73e17580eb900e876102d45ab2374207a84531715d1315b</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Balsamiq/BalsamiqMockups.filewave.recipe
+++ b/Balsamiq/BalsamiqMockups.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.thenikola.download.BalsamicMockups</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>BalsamiqMockupsURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>4d57695fa7098dc5a13b722cb5614bbdd18f8b46</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.thenikola-recipes/BalsamiqMockups/BalsamiqMockupsURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>0562514a6105038016aaf8cf42e559b6f73f568062ba3e4c35b6cf3d738164b9</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.thenikola.download.BalsamicMockups</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8e54095560680be843af4efa788c214b2ea84598</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.thenikola-recipes/BalsamiqMockups/BalsamiqMockups.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>edbacd6604e3882bdecb84a742657d54ba704ea96063e836d49a4de4af9c0dbe</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BetterTouchTool/BetterTouchTool.filewave.recipe
+++ b/BetterTouchTool/BetterTouchTool.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.BetterTouchTool</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.BetterTouchTool</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8a011dfd74579a361268b4c6d5cd07e7e9166b9c</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/BetterTouchTool/BetterTouchTool.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>811d95d467a68e59b8982664ad77e05ec64c3ca9f5a187bd07ee5da501e45976</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BitcoinCore/BitcoinCore.filewave.recipe
+++ b/BitcoinCore/BitcoinCore.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.BitcoinCore</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.BitcoinCore</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/BitcoinCore/BitcoinCore.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>1133c11b8250243168dacecd0a66955d4f1fca0ea92ee98ff2df3278af1be8d6</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CCleaner/CCleaner.filewave.recipe
+++ b/CCleaner/CCleaner.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.CCleaner</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.CCleaner</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8c682bf8bb1a318a2f17af0ef17286666abb43e9</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/CCleaner/CCleaner.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>2a08e645c8496539484ff0e909be98ce8c6f3cfe3beb43c36c9c5b5cbc875dba</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Caffeine/Caffeine.filewave.recipe
+++ b/Caffeine/Caffeine.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.Caffeine.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.Caffeine.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>f6df176e67433ef78fb1621ca56724a5e8bc4860</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/Caffeine/Caffeine.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>0f46f4d83d6c4ba54f7ca8a7406ead1ef8921a90b8444ab04693b1e84e050e64</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CheatSheet/CheatSheet.filewave.recipe
+++ b/CheatSheet/CheatSheet.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.CheatSheet</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.CheatSheet</key>
-			<dict>
-				<key>git_hash</key>
-				<string>686e5e19b7bafea36ccffaad2900f4c73f624858</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/CheatSheet/CheatSheet.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>9abcb08b5acaa3aeb2671896a68481ed5b7c5594da14a961f942d91fb0a21b13</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Chicken/Chicken.filewave.recipe
+++ b/Chicken/Chicken.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.Chicken.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.Chicken.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>bd68c2f451bb7d088705102a1a0fddc543c48f37</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/Chicken/Chicken.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>6e24e0484972c739f5e2d53dee0861878263f859c79b18bb16e9a542fb7827ec</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ClamXav/ClamXav.filewave.recipe
+++ b/ClamXav/ClamXav.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.ClamXav</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.ClamXav</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8a011dfd74579a361268b4c6d5cd07e7e9166b9c</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/ClamXav/ClamXav.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>038160ce096f48407736c8844857717290ff8c30995150dd6e201cf68db43413</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ClipGrab/ClipGrab.filewave.recipe
+++ b/ClipGrab/ClipGrab.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.ClipGrab</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.ClipGrab</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/ClipGrab/ClipGrab.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a8b36feb1348e65b64d461b6784b990f0ce94382fe6e52b9192ce1016c3bf969</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Colloquy/Colloquy.filewave.recipe
+++ b/Colloquy/Colloquy.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.Colloquy.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.Colloquy.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>bd68c2f451bb7d088705102a1a0fddc543c48f37</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/Colloquy/Colloquy.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>8ebe38f2345687320f5b0d2a244505cf6546b015098c8a314f1aeaeeb7538268</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Curb/Curb.filewave.recipe
+++ b/Curb/Curb.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.andrewvalentine.download.curb</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.andrewvalentine.download.curb</key>
-			<dict>
-				<key>git_hash</key>
-				<string>e2b151eeb1634c415fa711414eb8d3b041434818</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.andrewvalentine-recipes/curb/curb.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f671549a549e0662a7f16227e44eedec3311081fcf415deebadf0e266f146f5d</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Deluge/Deluge.filewave.recipe
+++ b/Deluge/Deluge.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.thenikola.download.Deluge</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>DelugeURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9c354131a31642c787c084db5ae17869a0ed0b46</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.thenikola-recipes/Deluge/DelugeURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>298a9ef7e024b592451d88bdbd8f842a8c62a54f409aab74228e5c7660af3437</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.thenikola.download.Deluge</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8e54095560680be843af4efa788c214b2ea84598</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.thenikola-recipes/Deluge/Deluge.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>51b02f777052730a8e948edc5093d5e8096df329ab907443ea5407d9bac13457</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Dropbox/Dropbox.filewave.recipe
+++ b/Dropbox/Dropbox.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.dropbox</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.dropbox</key>
-			<dict>
-				<key>git_hash</key>
-				<string>29e505418bf6e344ae43a4d5c847638153d142d1</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Dropbox/Dropbox.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>6b3f290f226e7ae1e47b1acc0494c3c395ecb15c755803d24776cbbdf97157af</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Duplicate/Duplicate.filewave.recipe
+++ b/Duplicate/Duplicate.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Duplicate</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.Duplicate</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9106aba72c5efd58ddb6cc82361d8f84f61ffed5</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Duplicate/Duplicate.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a038c63825cff747c080c6a9fd09248f3583e672e9e3151bda931a2c74054c3e</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/EasyFind/EasyFind.filewave.recipe
+++ b/EasyFind/EasyFind.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jleggat.EasyFind.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jleggat.EasyFind.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d473e910f277356f5cba70928b467ab8abda59c0</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes/EasyFind/EasyFind.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>9e8f88d4895527df92b5ca517b30a1d470723679d329314948ba389fdf2250f0</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Eclipse/Eclipse.filewave.recipe
+++ b/Eclipse/Eclipse.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.sheagcraig.download.Eclipse</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OptionSelector</key>
-			<dict>
-				<key>git_hash</key>
-				<string>496f57602509a778c415bb41dd2d421fe5ddb58f</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes/Eclipse/OptionSelector.py</string>
-				<key>sha256_hash</key>
-				<string>827fd51b22cfa5e8492b9787fb171ad3ce88d2b3e39e80f55c111e90209dbb92</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.sheagcraig.download.Eclipse</key>
-			<dict>
-				<key>git_hash</key>
-				<string>b99b78f32b4b1b53398fe704fe6a55339d9e3967</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes/Eclipse/Eclipse.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>503e96e41de6dc332f9dfdf41d8840164778b27517d498e07a2eb7c2cb3738dd</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Evernote/Evernote.filewave.recipe
+++ b/Evernote/Evernote.filewave.recipe
@@ -20,23 +20,6 @@
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.Evernote</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.Evernote</key>
-			<dict>
-				<key>git_hash</key>
-				<string>ebcbf5b5b3e600b329bf15d412217fd5ecbb4ff8</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Evernote/Evernote.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>0a4c58e9f0ff617bcefddf22e6dba8c5d50758ce952a9888264c47094f0dbf76</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FileZilla/FileZilla.filewave.recipe
+++ b/FileZilla/FileZilla.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.FileZilla.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>FileZillaURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>94d81d1e796db36cd4f56fab8de5ceca6a04f966</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/FileZilla/FileZillaURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>74a0df416ade8dbbc70169b48fe7acd4eb0dae2794999ab4bda895323c646220</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.FileZilla.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>b0cea7d89566df5c0e2a92cfebff2734ca6c538b</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/FileZilla/FileZilla.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>2933e3b1ffbb88f76625ccc10424540f0e3cc765055ebb735008e8873a58e36e</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Flux/Flux.filewave.recipe
+++ b/Flux/Flux.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.Flux.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.Flux.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>bd68c2f451bb7d088705102a1a0fddc543c48f37</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/Flux/Flux.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>cb99c17e595a96461ca7952e2e1bc6c1ce5b56a248526923db86c1f6e059cb20</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FortiClient/FortiClient.filewave.recipe
+++ b/FortiClient/FortiClient.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.FortiClient</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.FortiClient</key>
-			<dict>
-				<key>git_hash</key>
-				<string>53835aae9bcf929ec08531aabfc639eab1399a0a</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/FortiClient/FortiClient.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>75937b811f7742bfa1834aaf812586b5d0518da8ef7907e87444ee4c20a83373</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GPGTools/GPGSuite.filewave.recipe
+++ b/GPGTools/GPGSuite.filewave.recipe
@@ -17,23 +17,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.gerardkok.download.GPGSuite</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.gerardkok.download.GPGSuite</key>
-			<dict>
-				<key>git_hash</key>
-				<string>55a1a09c8b8d2c79678ba862c53ea0d09c1ae1fe</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.gerardkok-recipes/GPGTools/GPGSuite.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>eb03e307626bc690bba2be18fae2d5a01b09369527c4b27b9ab7b06bd1fcd645</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GasMask/GasMask.filewave.recipe
+++ b/GasMask/GasMask.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.GasMask</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.GasMask</key>
-			<dict>
-				<key>git_hash</key>
-				<string>3d61141f85d0090f9c21ffa03a7417b644abbb5f</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GasMask/GasMask.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>915594b3d393298e1169c1514899ea5f2f9749ce6b9d58818f0e7aa6f56ef305</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GitHub/GitHubDesktop.filewave.recipe
+++ b/GitHub/GitHubDesktop.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.GitHubDesktop</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.GitHubDesktop</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8c682bf8bb1a318a2f17af0ef17286666abb43e9</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitHub/GitHubDesktop.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>60644bd8c866f41f70c94562e4ad1284d48b1a593d9c52e3c60e903807d49a06</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Go2Shell/Go2Shell.filewave.recipe
+++ b/Go2Shell/Go2Shell.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.Go2Shell</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.Go2Shell</key>
-			<dict>
-				<key>git_hash</key>
-				<string>dc326244d2b52605c5720c9f06f2b4d80bd8aa3c</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/ZipZapMac/Go2Shell.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>1489beb8b3aa836971d83f4516449677a6f0358c1b6fa8e28c7722b0409f714f</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Google/GoogleDrive.filewave.recipe
+++ b/Google/GoogleDrive.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.derak.download.GoogleDrive</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.derak.download.GoogleDrive</key>
-			<dict>
-				<key>git_hash</key>
-				<string>2127d358ce3eaf0b221e39b1b8fb8d06a60b4ac7</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.derak-recipes/Google/GoogleDrive.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>c33a1f941a7a3ea4d3a19ace76037c915ac73317529c3fbdcaeae59b1bb25304</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Handbrake/Handbrake.filewave.recipe
+++ b/Handbrake/Handbrake.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.Handbrake</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.Handbrake</key>
-			<dict>
-				<key>git_hash</key>
-				<string>ac81e5e06db47f60ad8d294680ae669ebb7c61a7</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Handbrake/Handbrake.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>fb1c663a887520371cf1dbb618f41b3bee34a8f58a39983cea367071af14f446</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InsomniaX/InsomniaX.filewave.recipe
+++ b/InsomniaX/InsomniaX.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.InsomniaX.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.InsomniaX.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>bd68c2f451bb7d088705102a1a0fddc543c48f37</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/InsomniaX/InsomniaX.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>e85ba676e1497b926fb2a65bf712cf29158fa99b2f5b395a9db051430a964164</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InstallDiskCreator/InstallDiskCreator.filewave.recipe
+++ b/InstallDiskCreator/InstallDiskCreator.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.InstallDiskCreator</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.InstallDiskCreator</key>
-			<dict>
-				<key>git_hash</key>
-				<string>4548f3180f037b66bf99bde743f4275a787e57e8</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/InstallDiskCreator/InstallDiskCreator.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a5c7e940a63bffd2782d8c9a4c8e3a85e1fba3e8d62f2c68327cd95d6cbb8d48</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Itsycal/Itsycal.filewave.recipe
+++ b/Itsycal/Itsycal.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jleggat.Itsycal.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jleggat.Itsycal.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>0516c187470af3db942f3e5d9e7fe5d2c25ed289</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes/Itsycal/Itsycal.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f14303c10e4aacf65947fd02d57502a74861b59a630915a917f4705a44863461</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/LibreOffice/LibreOffice.filewave.recipe
+++ b/LibreOffice/LibreOffice.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.LibreOffice</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8b6a277dd5915929ac29ae5e76a1de449f7ed10a</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/LibreOffice/LibreOffice.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>e6adc0690acbb6061ed86c7ca5093bd2ff94d6518aaa7d4798176297527a4380</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MPlayerX/MPlayerX.filewave.recipe
+++ b/MPlayerX/MPlayerX.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.MPlayerX</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.MPlayerX</key>
-			<dict>
-				<key>git_hash</key>
-				<string>df077177c63205aea254ed3a2cad428fcf02fb73</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/MPlayerX/MPlayerX.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>bb4a30c6f0f0b46f06ff7e2a519a38e62592ddaedd8668650747539e592d337e</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MTR/MTR.filewave.recipe
+++ b/MTR/MTR.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.MTR</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.MTR</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/MTR/MTR.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a79c5124260f61c3824dd1b57603a0ed8ec32fe6b281758d4b86214be84dcdb6</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mactracker/Mactracker.filewave.recipe
+++ b/Mactracker/Mactracker.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.arubdesu.download.Mactracker</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.arubdesu.download.Mactracker</key>
-			<dict>
-				<key>git_hash</key>
-				<string>53f63ff6eb38b9efe4bf80bfa0d3a20e916453a7</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes/Mactracker/Mactracker.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>259c72edcab21d12979ba8737fb77619b6889952f6e7b9df9a011317fd8e5cad</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mattermost/Mattermost.filewave.recipe
+++ b/Mattermost/Mattermost.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Mattermost</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.Mattermost</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Mattermost/Mattermost.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a08bb33dcc4c2502c4da4bbc32657db279955647ec342687fd80e989cf32e1f2</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Microsoft/MSWord2016.filewave.recipe
+++ b/Microsoft/MSWord2016.filewave.recipe
@@ -35,33 +35,6 @@ used by other processors in a child recipe.
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.MSWord2016</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>MSOffice2016URLandUpdateInfoProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>788b44632d67de45878dfc2b670ef83a69ad404b</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py</string>
-				<key>sha256_hash</key>
-				<string>67d0e13ccce7f888677c25c140b0d30d22aa0215c94737203a2c4d17e5e7db1d</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.MSWord2016</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d49d9febcf853d0809eb99c54cee83ca1ffac997</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/MSOfficeUpdates/MSWord2016.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>8d1d9f32b56d4cc8b434d1fcbdb5db1b64ea0cbcc462a4926cc71370c7ecf043</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mindjet/MindManager.filewave.recipe
+++ b/Mindjet/MindManager.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.MindManager</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.MindManager</key>
-			<dict>
-				<key>git_hash</key>
-				<string>663c8ae40013e6f340a810c6dc4750dd7d1b4a95</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Mindjet/MindManager.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f70b1800fe05994f6e0b5ad6bd8cdc13d84594d98f195703c3bf08c34d00e1ba</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mozilla/Firefox.filewave.recipe
+++ b/Mozilla/Firefox.filewave.recipe
@@ -21,33 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.firefox-rc-en_US</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>MozillaURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8332edca4fbafc1e8aff8c119e571f27b4853bb5</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/MozillaURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>b3c2711d58a670f13d186f77743fd0808470d387fd780b852e8fcfcecdbec251</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.firefox-rc-en_US</key>
-			<dict>
-				<key>git_hash</key>
-				<string>1389f3bf17dfa5392e75f5be71efbb96fa0994db</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/Firefox.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>ce60d336bef2197004d2a1881d528338fb04e7e76972e98902f9abc6c84a922e</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mumble/Mumble.filewave.recipe
+++ b/Mumble/Mumble.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.triti.download.Mumble</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.triti.download.Mumble</key>
-			<dict>
-				<key>git_hash</key>
-				<string>7000a34f7c0c868fd9a4f4624d5a2448d395ef31</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.triti-recipes/Mumble/Mumble.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>5c5a942042cc651475dacc42acdcba16b03cb2caec7942da073fc236a60ef48b</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NetSpot/NetSpot.filewave.recipe
+++ b/NetSpot/NetSpot.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jaharmi.download.NetSpot</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jaharmi.download.NetSpot</key>
-			<dict>
-				<key>git_hash</key>
-				<string>7cd1a4a67d2c81395f9ee1d8b1f6f440458a22f2</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jaharmi-recipes/Etwok/NetSpot.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>7071ef52d60226368a336ebc0db924da76b85d2567382af22fb03bc82cfb2166</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Onyx/Onyx.filewave.recipe
+++ b/Onyx/Onyx.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.tallfunnyjew.download.Onyx1012</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.tallfunnyjew.download.Onyx1012</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8d132009a414a3f75fc46b99b663d71654304224</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.tallfunnyjew-recipes/Onyx10.12/Onyx10.12.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a7d81d5490e0ebc1433c638a85bbea41c4aba77182e673dc888a96fedc34d371</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OpenOffice/OpenOffice.filewave.recipe
+++ b/OpenOffice/OpenOffice.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.OpenOffice</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OpenOfficeURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>49471a06962adde75e64ec73f0a2d6ceaeaccf4f</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/OpenOffice/OpenOfficeURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>bb4ff833bf4019f0515253f9d404646cb43da95c3338cfbac30deed484aa1591</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.OpenOffice</key>
-			<dict>
-				<key>git_hash</key>
-				<string>49471a06962adde75e64ec73f0a2d6ceaeaccf4f</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/OpenOffice/OpenOffice.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>a6765942108e359e26f710db59db240274ffdab73a8ddc7c05074d9b33cc2547</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Opera/Opera.filewave.recipe
+++ b/Opera/Opera.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.bochoven.recipes.Opera.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OperaUpdateInfoProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>599ccd85602168998f5945933627534bf661670f</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.bochoven-recipes/Opera/OperaUpdateInfoProvider.py</string>
-				<key>sha256_hash</key>
-				<string>de6fe8ecc5b822df9cba526aed9bdbc3461c4ef04f8d0f65982eeefff477905a</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.bochoven.recipes.Opera.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>fa31187686ef51931e3227a22a7fe56eebd9af13</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.bochoven-recipes/Opera/Opera.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>c1e685189916aac679004bd0a2ed421809ef8b285485ecb9616af64e3af232e7</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OxygenXML/OxygenAuthorMacOSX.filewave.recipe
+++ b/OxygenXML/OxygenAuthorMacOSX.filewave.recipe
@@ -21,33 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.OxygenAuthor</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OxygenURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>28b7662a16460a78fa11d2e7ed0019db0882e2e3</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>8a2606a47013352753ee2439ab5258e31509a2736c2364566c54117e7dfe0bcf</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.OxygenAuthor</key>
-			<dict>
-				<key>git_hash</key>
-				<string>05e3100546e75a8df2b0683c58061e0aa2ef393d</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenAuthor.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>871c78ee25efeeb426c5a782be24e7c33d9cdd795d44dba5b2b9850f1445b9d6</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OxygenXML/OxygenDeveloperEclipse.filewave.recipe
+++ b/OxygenXML/OxygenDeveloperEclipse.filewave.recipe
@@ -21,33 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.OxygenDeveloper</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OxygenURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>28b7662a16460a78fa11d2e7ed0019db0882e2e3</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>8a2606a47013352753ee2439ab5258e31509a2736c2364566c54117e7dfe0bcf</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.OxygenDeveloper</key>
-			<dict>
-				<key>git_hash</key>
-				<string>05e3100546e75a8df2b0683c58061e0aa2ef393d</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenDeveloper.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>3b8a977546f9002c8422da7d61ba8ad1bd5c46f0dcd53cb2d8cfda411e6df498</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OxygenXML/OxygenDeveloperMacOSX.filewave.recipe
+++ b/OxygenXML/OxygenDeveloperMacOSX.filewave.recipe
@@ -21,33 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.OxygenDeveloper</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OxygenURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>28b7662a16460a78fa11d2e7ed0019db0882e2e3</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>8a2606a47013352753ee2439ab5258e31509a2736c2364566c54117e7dfe0bcf</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.OxygenDeveloper</key>
-			<dict>
-				<key>git_hash</key>
-				<string>05e3100546e75a8df2b0683c58061e0aa2ef393d</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenDeveloper.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>3b8a977546f9002c8422da7d61ba8ad1bd5c46f0dcd53cb2d8cfda411e6df498</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OxygenXML/OxygenEditorMacOSX.filewave.recipe
+++ b/OxygenXML/OxygenEditorMacOSX.filewave.recipe
@@ -21,33 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.OxygenEditor</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OxygenURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>28b7662a16460a78fa11d2e7ed0019db0882e2e3</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>8a2606a47013352753ee2439ab5258e31509a2736c2364566c54117e7dfe0bcf</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.OxygenEditor</key>
-			<dict>
-				<key>git_hash</key>
-				<string>05e3100546e75a8df2b0683c58061e0aa2ef393d</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenEditor.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>9af03fa7571dbabd948c8d104540a5d85ce2934f2b4e99a5f632620cbcd8359d</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OxygenXML/OxygenWebAuthor.filewave.recipe
+++ b/OxygenXML/OxygenWebAuthor.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.OxygenWebAuthor</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OxygenURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>28b7662a16460a78fa11d2e7ed0019db0882e2e3</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>8a2606a47013352753ee2439ab5258e31509a2736c2364566c54117e7dfe0bcf</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.OxygenWebAuthor</key>
-			<dict>
-				<key>git_hash</key>
-				<string>94ea93c808cf53f825f0a63d00597d3e6e25a404</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenWebAuthor.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>1fb6a0604087025caa9080d7c2db23b2339244fb064cd82c88a0e51279a3cc2c</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OxygenXML/OxygenWebHelp.filewave.recipe
+++ b/OxygenXML/OxygenWebHelp.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.OxygenWebHelp</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>OxygenURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>28b7662a16460a78fa11d2e7ed0019db0882e2e3</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>8a2606a47013352753ee2439ab5258e31509a2736c2364566c54117e7dfe0bcf</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.OxygenWebHelp</key>
-			<dict>
-				<key>git_hash</key>
-				<string>ee58e6b31e0573025182f0cdf772ffac379018e5</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/OxygenXML/OxygenWebHelp.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>b8020fe68b7ad79aa6e923519efab98507fc1d842e522596c53f1b66c5ddbef6</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PDFsam/PDFsam.filewave.recipe
+++ b/PDFsam/PDFsam.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.andrewvalentine.download.pdfsam</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.andrewvalentine.download.pdfsam</key>
-			<dict>
-				<key>git_hash</key>
-				<string>4031853d5aa5574f4ab87dc92d4363c11a4258e3</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.andrewvalentine-recipes/pdfsam/pdfsam.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>06af73a8f4a296ef834d436d85939e8e46eedd99c70249710a9c22e393088af1</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PaloAlto/GlobalProtectMac.filewave.recipe
+++ b/PaloAlto/GlobalProtectMac.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.GlobalProtect</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.GlobalProtect</key>
-			<dict>
-				<key>git_hash</key>
-				<string>2d81a392af3bc0f09b4321f8208e87da2e27c0dc</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/PaloAlto/GlobalProtect.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>e185a75061ba2a7bf033f2831905399dbe92fa69031d71db78b6fd179272f9a2</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Parallels/ParallelsDesktopDeploy.filewave.recipe
+++ b/Parallels/ParallelsDesktopDeploy.filewave.recipe
@@ -19,30 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.pkg.ParallelsDesktopDeploy</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.ParallelsDesktop</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d880f7890123933cdb010acad47d21b57e1a0b9c</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Parallels/ParallelsDesktop.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f21c093efa95b2f0ac4e6dbec232ce6efd99fe473cc1a52efc1068b7feec7975</string>
-			</dict>
-			<key>com.github.peshay.pkg.ParallelsDesktopDeploy</key>
-			<dict>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Parallels/ParallelsDesktopDeploy.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>688b281354ea4a9563a63a02de75bc3f43af42774e2b12eeff122cf52b4c1b5f</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Parallels/ParallelsDesktopDeploy.pkg.recipe
+++ b/Parallels/ParallelsDesktopDeploy.pkg.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.ParallelsDesktop</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.ParallelsDesktop</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d880f7890123933cdb010acad47d21b57e1a0b9c</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Parallels/ParallelsDesktop.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f21c093efa95b2f0ac4e6dbec232ce6efd99fe473cc1a52efc1068b7feec7975</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Platypus/Platypus.filewave.recipe
+++ b/Platypus/Platypus.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Platypus</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.Platypus</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d4c036ce186ba54fb6d405a3daad5b58528b1c0c</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Platypus/Platypus.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>cbb79f07267992b987a1abdbd548cae407cccdad94ebc3fa0aa97a52246aafa5</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PostgresApp/PostgresApp.filewave.recipe
+++ b/PostgresApp/PostgresApp.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jleggat.PostgresApp.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jleggat.PostgresApp.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d9c068e0f5c739d5834edafc7ab93947e7605eb3</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes/PostgresApp/PostgresApp.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>7a5debe57657d8a9e29d4a79bdc6e5479f4272c5cb36d8fc98d3c412b9e25030</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Prey/Prey.filewave.recipe
+++ b/Prey/Prey.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.hansen-m.download.Prey</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.hansen-m.download.Prey</key>
-			<dict>
-				<key>git_hash</key>
-				<string>0326d1c53a87beaca631b09dc96cd1bdf4ee37ba</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes/PreyProject/Prey.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>e9d8615f4358c1e143a0bcfb89325eff84dd0ebccb87e31a720e8f8ce45454a2</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ProjectWizards/MerlinProject.filewave.recipe
+++ b/ProjectWizards/MerlinProject.filewave.recipe
@@ -21,23 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.MerlinProject</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.MerlinProject</key>
-			<dict>
-				<key>git_hash</key>
-				<string>abb8a7a1dd6f0dfa3e23de17829e083126474304</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/MerlinProject/MerlinProject.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>164a231bc2ac0a937ec1a985d70caf98e15afa670545f58a0ce3e4232b181301</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RawTherapee/RawTherapee.filewave.recipe
+++ b/RawTherapee/RawTherapee.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.RawTherapee</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.RawTherapee</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/RawTherapee/RawTherapee.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>67fda805869dab3bcf60a8128e426ee1418e2d10e805526006fa6f5046019826</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ScreenFlow/ScreenFlow.filewave.recipe
+++ b/ScreenFlow/ScreenFlow.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.ScreenFlow</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.ScreenFlow</key>
-			<dict>
-				<key>git_hash</key>
-				<string>3204076c016708f637477f80042e33f1d08002f0</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/ScreenFlow/ScreenFlow.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>7e24d6c03a5574dbcaeb3b93a447231efa04429d470d7e7a4fa84e35a44a4b16</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ScreenFlow5/ScreenFlow.filewave.recipe
+++ b/ScreenFlow5/ScreenFlow.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.ScreenFlow5</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.ScreenFlow5</key>
-			<dict>
-				<key>git_hash</key>
-				<string>2cb86fa25302130244d72dfccda8283fe27bd952</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/ScreenFlow5/ScreenFlow.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>b4bfbaf13a520f4f3faf309145535cd7eb39ebe1945b3995b56fd9ff638df652</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Skitch/Skitch.filewave.recipe
+++ b/Skitch/Skitch.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.sheagcraig.download.Skitch</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.sheagcraig.download.Skitch</key>
-			<dict>
-				<key>git_hash</key>
-				<string>f009ecea03eedd179e35c10e5015e9b992a1d9fe</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes/Skitch/Skitch.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>34588853141241eb0b059cec0cd25aa4cd768df19b0d14bfa6250e3d872c23a9</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Snk/Snk.filewave.recipe
+++ b/Snk/Snk.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Snk</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.Snk</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Snk/Snk.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>b367ece6e5321d4847b58a7434294c3292152409bee2e5e7f8daed17fa44dab9</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SublimeText/SublimeText3.filewave.recipe
+++ b/SublimeText/SublimeText3.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.SublimeText.SublimeText3.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.keeleysam.recipes.SublimeText.SublimeText3.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9ea4ad1be9603bc312c439c6810a9e07c374e9fc</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes/SublimeText/SublimeText3.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>5bd3875dc38bce30bcfc921627db5f0e8bb375509ec6ff360e5ce319152aa0d8</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TeXstudio/TeXstudio.filewave.recipe
+++ b/TeXstudio/TeXstudio.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.TeXstudio</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>io.github.hjuutilainen.download.TeXstudio</key>
-			<dict>
-				<key>git_hash</key>
-				<string>b023c2e77d485198fa6d605e909b4d21587a5009</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/TeXstudio/TeXstudio.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>00c79ee6ee6093f8f1a2ecbf6fad01fb24b14a92c4f17206e84c4ccf9f9cbac6</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TeamSpeak/TeamSpeak.filewave.recipe
+++ b/TeamSpeak/TeamSpeak.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.TeamSpeak</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.TeamSpeak</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/TeamSpeak/TeamSpeak.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>29517fa7b9abced7e3db4bc390a076080c2c4f12665dc333768ffd0a370ab7c2</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Telegram/Telegram.filewave.recipe
+++ b/Telegram/Telegram.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Telegram</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.Telegram</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Telegram/Telegram.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>040a5d7db0d0e522fd822746d273cc5b8562b32535665bc98f29f5be55050aad</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Telestream/ScreenFlow.filewave.recipe
+++ b/Telestream/ScreenFlow.filewave.recipe
@@ -21,23 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.rderewianko.download.ScreenFlow</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.rderewianko.download.ScreenFlow</key>
-			<dict>
-				<key>git_hash</key>
-				<string>a7b01315f4a70b0f6b5f87095c409401e5d49570</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.rderewianko-recipes/ScreenFlow/ScreenFlow.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>b0915752c8dc2ab5e94072f29fa825a0f88d387ecb53801ea3e6e549bc6cc9d4</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TextWrangler/TextWrangler.filewave.recipe
+++ b/TextWrangler/TextWrangler.filewave.recipe
@@ -19,33 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.textwrangler</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>BarebonesURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>c4a6bacbba3a00ff24f0914efcd9159eb26999ba</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BarebonesURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>f23c5f4769d3be3f29d1e573867275ae63e38c23e56b39250478c3159927a33f</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.textwrangler</key>
-			<dict>
-				<key>git_hash</key>
-				<string>937886757bbb1981b1179263f2aed613fea1d53d</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/TextWrangler.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>9e10b50a7087d36f58ba0385d5385f1be65406c988037dbf910b58c4cc91d2f5</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TheUnarchiver/TheUnarchiver.filewave.recipe
+++ b/TheUnarchiver/TheUnarchiver.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.TheUnarchiver</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.download.TheUnarchiver</key>
-			<dict>
-				<key>git_hash</key>
-				<string>ce9996b461d6d6a03a639fb37f49da4d5e6e03e5</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/The Unarchiver/TheUnarchiver.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>dee2e0c13b3f5e5446ec119c638be2792640794aaebbe55fb3005b5947d49682</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tor/TorBrowser.filewave.recipe
+++ b/Tor/TorBrowser.filewave.recipe
@@ -21,23 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.TorBrowserBundle</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.TorBrowserBundle</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9a05bb6963e6739056a10a3d72453c4df2cb92e6</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Tor/TorBrowserBundle.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>37f4091badd2251ae7bf1a1744b4ff0ac93846d623a1c47e02d5b12191099a9a</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tor/TorMessenger.filewave.recipe
+++ b/Tor/TorMessenger.filewave.recipe
@@ -21,23 +21,6 @@
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.TorMessenger</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.TorMessenger</key>
-			<dict>
-				<key>git_hash</key>
-				<string>00025ae3581a7b0aa903e1d80da820907fcf05ae</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Tor/TorMessenger.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>b028ba22ec9c509504905aafdd1300b428b168b97d958e9974a9d81b246bf1cb</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/UNetbootin/UNetbootin.filewave.recipe
+++ b/UNetbootin/UNetbootin.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.UNetbootin</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.UNetbootin</key>
-			<dict>
-				<key>git_hash</key>
-				<string>25ae11ad92939cc3d979fd5204fbce2f6c91ab5c</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/UNetbootin/UNetbootin.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>c8b2836d8ec7d5110ccb8da3c0e43073f7fb6f06edaa8d1618dca557f1d5fe42</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/UnRarX/UnRarX.filewave.recipe
+++ b/UnRarX/UnRarX.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.UnRarX</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.UnRarX</key>
-			<dict>
-				<key>git_hash</key>
-				<string>f68477e34af1447016db7b6bf08ff9045fe6a14a</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/UnRarX/UnRarX.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>30b504db82df82a290b5c6f897e48d4dec9bec8f8d6a3301b763385c1e8f3707</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Usage/Usage.filewave.recipe
+++ b/Usage/Usage.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Usage</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.Usage</key>
-			<dict>
-				<key>git_hash</key>
-				<string>675b5dfa397f5402d9d400ed8bfc6ee7f1f421f1</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Usage/Usage.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>468820e3605909903aeefd47507992d9ad1d48b084991ff749d517ac5a775e3a</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VMware/VMwareFusionDeploy.filewave.recipe
+++ b/VMware/VMwareFusionDeploy.filewave.recipe
@@ -21,42 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.patgmac.pkg.VMwareFusionDeploy</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>VMwareFusionURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>682aa5137ad752e17783bf4a3a43dc3afe4b344e</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware Fusion/VMwareFusionURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>ba9ca63ac19aef71e0081d7abb7776a2e2cdd93e7071e895f384089cac41f547</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.patgmac.pkg.VMwareFusionDeploy</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8e50e891e8a550ddc8bf5b75da45fbea296f90eb</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.patgmac-recipes/VMware Fusion/VMwareFusionDeploy.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>2907780787660ed1edaa6c9cf5e8c1039d26eb19b658d44894ae1dcb942fe601</string>
-			</dict>
-			<key>com.justinrummel.download.VMwareFusion</key>
-			<dict>
-				<key>git_hash</key>
-				<string>3b408aa5b9bdb04fe6f1ab78254bd7ff44743f61</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware Fusion/VMwareFusion.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>0fbc6c7dd668a296a7709e38a47b54e81360ec260ae27893bc4e1a75d917109f</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VirtualBox/VirtualBox.filewave.recipe
+++ b/VirtualBox/VirtualBox.filewave.recipe
@@ -19,32 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.sheagcraig.pkg.VirtualBox</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.sheagcraig.download.VirtualBox</key>
-			<dict>
-				<key>git_hash</key>
-				<string>ef71a5ad37488b7187e21bd3ea19f136753f3146</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes/VirtualBox/VirtualBox.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f232346691440eef33a0154055cada9054d5ef711e18152cb61c4ecd7b75c44f</string>
-			</dict>
-			<key>com.github.sheagcraig.pkg.VirtualBox</key>
-			<dict>
-				<key>git_hash</key>
-				<string>13fef4ea366eaeba5bfb1f3bf9b952b3a07abc49</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes/VirtualBox/VirtualBox.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>1fa9740264ce79350234fd39569a2f39f56bd866ff2912a87f2158dabfbd8f85</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Wireshark/Wireshark.filewave.recipe
+++ b/Wireshark/Wireshark.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jleggat.Wireshark.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jleggat.Wireshark.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>d27da8c9918a0edec67d6d470a1b970b164c9c2f</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes/Wireshark/Wireshark.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>7dd9055a619ae45f0fc700210d33a5162557cd46edd1a5754da9d1ceb91ea26d</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Xmind/XMind.filewave.recipe
+++ b/Xmind/XMind.filewave.recipe
@@ -21,33 +21,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.XMind</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict>
-			<key>XMindURLProvider</key>
-			<dict>
-				<key>git_hash</key>
-				<string>f4c8a76f2a7a0a912489e383d02a9050c424e1dd</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Xmind/XMindURLProvider.py</string>
-				<key>sha256_hash</key>
-				<string>0a04584a3d332d6fad7783e55d27880fe159ec5d9cf3029364d2050b660a13eb</string>
-			</dict>
-		</dict>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.peshay.download.XMind</key>
-			<dict>
-				<key>git_hash</key>
-				<string>1a4e51b774860d6ba4f855be6607960c19f3c921</string>
-				<key>path</key>
-				<string>/Users/ahu/git/peshay/peshay-recipes/Xmind/XMind.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>f648876458a6f1b5a81bf29abf05ca47c9ac53c4be459c3962d6596d77d69ac2</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/coconut Battery/coconutBattery.filewave.recipe
+++ b/coconut Battery/coconutBattery.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.coconutBattery</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.homebysix.download.coconutBattery</key>
-			<dict>
-				<key>git_hash</key>
-				<string>8a011dfd74579a361268b4c6d5cd07e7e9166b9c</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/coconutBattery/coconutBattery.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>815acbd22544f920d2bc999eb756854d93a8e0508043e3ba03c5dd5425c77afa</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/nvALT/nvALT.filewave.recipe
+++ b/nvALT/nvALT.filewave.recipe
@@ -19,23 +19,6 @@
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jleggat.nvALT.download</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.jleggat.nvALT.download</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9755cfa0843ef47d4d22150254fe0cf62ebd1bad</string>
-				<key>path</key>
-				<string>/Users/ahu/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes/nvAlt/nvALT.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>550a09602cdbdc10451249dc86639e7be5512b5b27c2370a7c35258189dcfcb3</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Trust info should only exist in overrides, not the recipes themselves.