### PR TITLE
Moved .download recipe for unetbootin to Github

### DIFF
--- a/UNetbootin/UNetbootin.download.recipe
+++ b/UNetbootin/UNetbootin.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of KeyStore Explorer.
+	<string>Downloads the latest version of UNetbootin.
 Set PRERELEASE to a non-empty string to download prereleases, either
 via Input in an override or via the -k option,
 i.e.: `-k PRERELEASE=yes`</string>

--- a/UNetbootin/UNetbootin.download.recipe
+++ b/UNetbootin/UNetbootin.download.recipe
@@ -3,59 +3,45 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of UNetbootin.</string> 
+	<string>Downloads the latest version of KeyStore Explorer.
+Set PRERELEASE to a non-empty string to download prereleases, either
+via Input in an override or via the -k option,
+i.e.: `-k PRERELEASE=yes`</string>
 	<key>Identifier</key>
 	<string>com.github.peshay.download.UNetbootin</string>
 	<key>Input</key>
 	<dict>
+	    <key>PRERELEASE</key>
+        <string></string>
 		<key>NAME</key>
-		<string>UNetbootin</string>
-		<key>OS</key>
-		<string>mac</string><!--  SELECT THE OS HERE (windows) or (mac) -->
+		<string>unetbootin</string>
 	</dict>
 	<key>MinimumVersion</key>
-    <string>0.6.1</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://unetbootin.github.io/</string>
-                <key>re_pattern</key>
-                <string>href="([^"]*)"&gt;[^"]*src="[^"]*" alt="%OS%"</string>
-                <key>re_flags</key>
-                <array>
-                    <string>IGNORECASE</string>
-                </array>
-                <key>result_output_var_name</key>
-                <string>url</string>
-            </dict>
-        </dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-                <key>url</key>
-                <string>%url%</string>
+				<key>github_repo</key>
+				<string>unetbootin/unetbootin</string>
+				<key>include_prereleases</key>
+				<string>%PRERELEASE%</string>
+				<key>asset_regex</key>
+				<string>[\S]+\.dmg</string>
 			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://launchpad.net/unetbootin/</string>
-                <key>re_pattern</key>
-                <string>Latest version is ([0-9]+)</string>
-                <key>result_output_var_name</key>
-                <string>version</string>
-            </dict>
-        </dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>


### PR DESCRIPTION
unetbootin is available now via GitHub.

Was getting errors with the .download, so updated.