### PR TITLE
Fixing and Tidying Google Web Designer Recipes

### DIFF
--- a/Google/WebDesigner.download.recipe
+++ b/Google/WebDesigner.download.recipe
@@ -2,29 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads latest version of Google WebDesigner.</string>
-    <key>Identifier</key>
-    <string>com.github.peshay.download.GoogleWebDesigner</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>GoogleWebDesigner</string>
-        <key>URL</key>
-        <string>https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.6.1</string>
-    <key>Process</key>
-    <array>
-        <dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
+	<key>Description</key>
+	<string>Downloads latest version of Google WebDesigner.</string>
+	<key>Identifier</key>
+	<string>com.github.peshay.download.GoogleWebDesigner</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>GoogleWebDesigner</string>
+		<key>URL</key>
+		<string>https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
 			<key>Arguments</key>
 			<dict>
-                <key>url</key>
-                <string>%URL%</string>
+				<key>url</key>
+				<string>%URL%</string>
 			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -35,21 +35,21 @@
 			<key>Processor</key>
 			<string>AppDmgVersioner</string>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%/*.app</string>
-                <key>requirement</key>
-                <string>identifier "com.google.WebDesigner" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/*.app</string>
+				<key>requirement</key>
+				<string>identifier "com.google.WebDesigner" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Google/WebDesigner.download.recipe
+++ b/Google/WebDesigner.download.recipe
@@ -50,17 +50,6 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-        <dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
-				<key>source_path</key>
-				<string>%pathname%/*.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>        
     </array>
 </dict>
 </plist>

--- a/Google/WebDesigner.filewave.recipe
+++ b/Google/WebDesigner.filewave.recipe
@@ -21,6 +21,17 @@
 	</dict>
 	<key>Process</key>
 	<array>
+        <dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<key>source_path</key>
+				<string>%pathname%/*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>        
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Google/WebDesigner.filewave.recipe
+++ b/Google/WebDesigner.filewave.recipe
@@ -6,45 +6,45 @@
 	<string>Downloads latest version of Google WebDesigner and imports into FileWave.</string>
 	<key>Identifier</key>
 	<string>com.github.peshay.filewave.GoogleWebDesigner</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>GoogleWebDesigner</string>
+		<key>fw_app_bundle_id</key>
+		<string>com.github.peshay.filewave.GoogleWebDesigner</string>
+		<key>fw_destination_root</key>
+		<string>/Applications/%NAME%.app</string>
+	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.GoogleWebDesigner</string>
-    <key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>GoogleWebDesigner</string>
-        <key>fw_app_bundle_id</key>
-        <string>com.github.peshay.filewave.GoogleWebDesigner</string>
-        <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
-	</dict>
 	<key>Process</key>
 	<array>
-        <dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
-                <key>overwrite</key>
-                <true/>
+				<key>overwrite</key>
+				<true/>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
-		</dict>        
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-                <key>fw_app_bundle_id</key>
+				<key>fw_app_bundle_id</key>
 				<string>%fw_app_bundle_id%</string>
 				<key>fw_app_version</key>
 				<string>%version%</string>
 				<key>fw_destination_root</key>
 				<string>%fw_destination_root%</string>
 				<key>fw_fileset_name</key>
-                <string>%NAME% - %version%</string>
+				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
 			</dict>

--- a/Google/WebDesigner.filewave.recipe
+++ b/Google/WebDesigner.filewave.recipe
@@ -26,6 +26,8 @@
 			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+                <key>overwrite</key>
+                <true/>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>


### PR DESCRIPTION
The Google Web Designer recipes would fail on the second run since the Copier processor in the download recipe would not overwrite the copy destination.  Added "overwrite" option to "Copier" processor.

Also moved the "Copier" processor to the Filewave recipe since it is only relevant to that recipe.

Also ran plutil -convert xml1 on the recipes to clean up formatting.