### PR TITLE
New macOS releases use "mac" as os version identificator.

### DIFF
--- a/Mattermost/Mattermost.download.recipe
+++ b/Mattermost/Mattermost.download.recipe
@@ -20,7 +20,7 @@
 -->
 
 		<key>os</key>
-		<string>osx</string><!-- <<<<<< INPUT HERE <<<<<< -->
+		<string>mac</string><!-- <<<<<< INPUT HERE <<<<<< -->
 	</dict>
 	<key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
I forget about this string in previous request.