### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/5KPlayer/5KPlayer.filewave.recipe
+++ b/5KPlayer/5KPlayer.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.5KPlayer</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/5KPlayer.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/ADPassMon/ADPassMon.filewave.recipe
+++ b/ADPassMon/ADPassMon.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.ADPassMon</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ADPassMon.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -37,7 +37,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/ADPassMon.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Alfred3/Alfred3.filewave.recipe
+++ b/Alfred3/Alfred3.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Alfred3</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Alfred3.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Apache/ApacheDirectoryStudio.filewave.recipe
+++ b/Apache/ApacheDirectoryStudio.filewave.recipe
@@ -15,7 +15,7 @@
 			<key>version</key>
 			<string>%version%</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/ApacheDirectoryStudio.app</string>
 		</dict>
 		<key>MinimumVersion</key>
 		<string>1.0.0</string>
@@ -41,7 +41,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>destination_path</key>
-					<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/Applications/ApacheDirectoryStudio.app</string>
 					<key>source_path</key>
 					<string>%pathname%/*.app</string>
 				</dict>
@@ -69,7 +69,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/Applications/ApacheDirectoryStudio.app</string>
 				</dict>
 				<key>Comment</key>
 				<string>Import the ApacheDirectoryStudio app into FileWave</string>

--- a/AppCleaner/AppCleaner.filewave.recipe
+++ b/AppCleaner/AppCleaner.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.AppCleaner</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/AppCleaner.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -37,7 +37,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/AppCleaner.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Atlassian/SourceTree.filewave.recipe
+++ b/Atlassian/SourceTree.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.SourceTree</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/SourceTree.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/SourceTree.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/SourceTree.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/AutoDMG/AutoDMG.filewave.recipe
+++ b/AutoDMG/AutoDMG.filewave.recipe
@@ -17,7 +17,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.AutoDMG</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/AutoDMG.app</string>
 		</dict>
 		<key>Process</key>
 		<array>
@@ -25,7 +25,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_plist_path</key>
-					<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+					<string>%pathname%/AutoDMG.app/Contents/Info.plist</string>
 				</dict>
 				<key>Processor</key>
 				<string>Versioner</string>
@@ -48,7 +48,7 @@
 	<key>Arguments</key>
 	<dict>
 		<key>destination_path</key>
-		<string>%pkgroot%/%NAME%.app</string>
+		<string>%pkgroot%/AutoDMG.app</string>
 		<key>source_path</key>
 		<string>%pathname%/*.app</string>
 	</dict>
@@ -67,7 +67,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%pkgroot%/%NAME%.app</string>
+					<string>%pkgroot%/AutoDMG.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Axure/AxureRP.filewave.recipe
+++ b/Axure/AxureRP.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.AxureRP</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Axure RP.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Axure RP.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Axure RP.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -50,7 +50,7 @@
             <key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Axure RP.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
 			</dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Axure RP.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Balena/Etcher.filewave.recipe
+++ b/Balena/Etcher.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Etcher</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/balenaEtcher.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/balenaEtcher.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/balenaEtcher.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Balsamiq/BalsamiqMockups.filewave.recipe
+++ b/Balsamiq/BalsamiqMockups.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.BalsamiqMockups</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Balsamiq Mockups 3.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Barebones/BBEdit.filewave.recipe
+++ b/Barebones/BBEdit.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.BBEdit</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/BBEdit.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/BBEdit.app</string>
                 <key>source_path</key>
                 <string>%pathname%/BBEdit.app</string>
             </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/BBEdit.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Barebones/TextWrangler.filewave.recipe
+++ b/Barebones/TextWrangler.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.TextWrangler</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/TextWrangler.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,9 +39,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/TextWrangler.app</string>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/TextWrangler.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/TextWrangler.app/Contents/Info.plist</string>
             </dict>
         </dict>
 		<dict>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/TextWrangler.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/BetterTouchTool/BetterTouchTool.filewave.recipe
+++ b/BetterTouchTool/BetterTouchTool.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.BetterTouchTool</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/BetterTouchTool.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/BetterTouchTool.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/BitBar/BitBar.filewave.recipe
+++ b/BitBar/BitBar.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.BitBar</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/BitBar.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -31,7 +31,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/BitBar.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.matryer.BitBar" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = B3T8QSC4HG)</string>
             </dict>
@@ -48,7 +48,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/BitBar.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/BitcoinCore/BitcoinCore.filewave.recipe
+++ b/BitcoinCore/BitcoinCore.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.BitcoinCore</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/BitcoinCore.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/BitcoinCore.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/BitcoinCore.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -59,7 +59,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/BitcoinCore.app</string>
 				<key>requirement</key>
 				<string>identifier "org.bitcoinfoundation.Bitcoin-Qt" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PBV4GLS9J4</string>
 			</dict>
@@ -78,7 +78,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/BitcoinCore.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Bluefish/Bluefish.filewave.recipe
+++ b/Bluefish/Bluefish.filewave.recipe
@@ -19,7 +19,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Bluefish</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Bluefish.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/Bluefish.app</string>
                 <key>source_path</key>
                 <string>%pathname%/Bluefish.app</string>
             </dict>
@@ -58,7 +58,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Bluefish.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>

--- a/BohemianCoding/Sketch.filewave.recipe
+++ b/BohemianCoding/Sketch.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Sketch</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Sketch.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%.0</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Sketch.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Bombich/CarbonCopyCloner.filewave.recipe
+++ b/Bombich/CarbonCopyCloner.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.CarbonCopyCloner</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Carbon Copy Cloner.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -27,7 +27,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications/Carbon Copy Cloner.app/Contents/Info.plist</string>
             </dict>
         </dict>
 		<dict>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Applications/Carbon Copy Cloner.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/BoxSync/BoxSync.filewave.recipe
+++ b/BoxSync/BoxSync.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.BoxSync</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/BoxSync.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>destination_path</key>
-                                <string>%pkgroot%/%NAME%.app</string>
+                                <string>%pkgroot%/BoxSync.app</string>
                                 <key>source_path</key>
                                 <string>%pathname%/*.app</string>
                         </dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-		<string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+		<string>%pkgroot%/BoxSync.app/Contents/Info.plist</string>
 		<key>plist_version_key</key>
                                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/BoxSync.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Brackets/Brackets.filewave.recipe
+++ b/Brackets/Brackets.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Brackets</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Brackets.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Brackets.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Brackets.app/Contents/Info.plist</string>
             </dict>
         </dict>
 		<dict>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Brackets.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/CCleaner/CCleaner.filewave.recipe
+++ b/CCleaner/CCleaner.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.CCleaner</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/CCleaner.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/CCleaner.app</string>
 				<key>source_path</key>
 				<string>%pathname%/%app_name%</string>
 			</dict>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/CCleaner.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Caffeine/Caffeine.filewave.recipe
+++ b/Caffeine/Caffeine.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Caffeine</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Caffeine.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Caffeine.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -48,7 +48,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Caffeine.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Calibre/Calibre.filewave.recipe
+++ b/Calibre/Calibre.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Calibre</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Calibre.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Calibre.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Calibre.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/CheatSheet/CheatSheet.filewave.recipe
+++ b/CheatSheet/CheatSheet.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.CheatSheet</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/CheatSheet.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CheatSheet.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CheatSheet.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Chicken/Chicken.filewave.recipe
+++ b/Chicken/Chicken.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Chicken</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Chicken.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Citrix/CitrixReceiver.filewave.recipe
+++ b/Citrix/CitrixReceiver.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.CitrixReceiver</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/CitrixReceiver.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Citrix/GoToMeeting.filewave.recipe
+++ b/Citrix/GoToMeeting.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.GoToMeeting</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/GoToMeeting.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>

--- a/ClamXav/ClamXav.filewave.recipe
+++ b/ClamXav/ClamXav.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.ClamXav</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ClamXav.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/ClamXav.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/ClipGrab/ClipGrab.filewave.recipe
+++ b/ClipGrab/ClipGrab.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.ClipGrab</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ClipGrab.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/ClipGrab.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/ClipGrab.app</string>
 				<key>requirement</key>
 				<string>identifier "de.clipgrab.ClipGrab" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = E8BJ3ZV5W8</string>
 			</dict>
@@ -61,7 +61,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/ClipGrab.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -80,7 +80,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/ClipGrab.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Colloquy/Colloquy.filewave.recipe
+++ b/Colloquy/Colloquy.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Colloquy</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Colloquy.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Colloquy.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -46,7 +46,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Colloquy.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Curb/Curb.filewave.recipe
+++ b/Curb/Curb.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Curb</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Curb.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Curb.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/DBBrowserforSQLite/DB Browser for SQLite.filewave.recipe
+++ b/DBBrowserforSQLite/DB Browser for SQLite.filewave.recipe
@@ -19,7 +19,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.DB Browser for SQLite</string>
 			<key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/DBBrowserforSQLite.app</string>
 		</dict>
 		<key>Process</key>
 		<array>
@@ -41,7 +41,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>destination_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/DBBrowserforSQLite.app</string>
 					<key>source_path</key>
 					<string>%RECIPE_CACHE_DIR%/downloads/%filename%/DB Browser for SQLite.app</string>
 				</dict>
@@ -60,7 +60,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/Applications/DBBrowserforSQLite.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/DBeaverCE/DBeaverCE.filewave.recipe
+++ b/DBeaverCE/DBeaverCE.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.DBeaverCE</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/DBeaverCE.app</string>
         <key>os</key>
 		<string>macos</string>
 	</dict>
@@ -41,7 +41,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/DBeaverCE.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/DBeaverCE.app</string>
                 <key>requirement</key>
                 <string>identifier "org.jkiss.dbeaver.core.product" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "42B6MDKMW8"</string>
             </dict>
@@ -71,7 +71,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/DBeaverCE.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/DOSBox/DOSBox.download.recipe
+++ b/DOSBox/DOSBox.download.recipe
@@ -68,7 +68,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/DOSBox.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -81,7 +81,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/DOSBox.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>

--- a/DOSBox/DOSBox.filewave.recipe
+++ b/DOSBox/DOSBox.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.DOSBox</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/DOSBox.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/DOSBox.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/DearMob/5kplayer.download.recipe
+++ b/DearMob/5kplayer.download.recipe
@@ -41,7 +41,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/5kplayer.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.digiarty.5kplayer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Q5K8LAV554)</string>
             </dict>

--- a/Deluge/Deluge.filewave.recipe
+++ b/Deluge/Deluge.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Deluge</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Deluge.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Deluge.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Deluge.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Deluge.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Docker/Docker.filewave.recipe
+++ b/Docker/Docker.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Docker</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Docker.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,9 +39,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/Docker.app</string>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Docker.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Docker.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Dropbox/Dropbox.filewave.recipe
+++ b/Dropbox/Dropbox.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Dropbox</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Dropbox.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Duplicate/Duplicate.download.recipe
+++ b/Duplicate/Duplicate.download.recipe
@@ -36,7 +36,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Duplicate.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Duplicate.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "io.macdaddy.duplicate" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8G7S5244GJ")</string>
             </dict>

--- a/Duplicate/Duplicate.filewave.recipe
+++ b/Duplicate/Duplicate.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Duplicate</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Duplicate.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Duplicate.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/EasyFind/EasyFind.filewave.recipe
+++ b/EasyFind/EasyFind.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.EasyFind</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/EasyFind.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/EasyFind.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/EasyFind.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "org.grunenberg.EasyFind" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "679S2QUWR8")</string>
 			</dict>
@@ -57,7 +57,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/EasyFind.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Enpass/Enpass.filewave.recipe
+++ b/Enpass/Enpass.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.enpass</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Enpass.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Evernote/Evernote.filewave.recipe
+++ b/Evernote/Evernote.filewave.recipe
@@ -14,7 +14,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.evernote.Evernote</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Evernote.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -45,7 +45,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Evernote.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 
 <dict>

--- a/FileZilla/FileZilla.filewave.recipe
+++ b/FileZilla/FileZilla.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.FileZilla</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/FileZilla.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -50,7 +50,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/FileZilla/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/FileZilla/FileZilla.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Flinto/Flinto.filewave.recipe
+++ b/Flinto/Flinto.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Flinto</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Flinto.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Flinto.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Flinto.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Flux/Flux.filewave.recipe
+++ b/Flux/Flux.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Flux</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Flux.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Flux.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Flux.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "org.herf.Flux" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VZKSA7H9J9)</string>
 			</dict>
@@ -57,7 +57,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Flux.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Flycut/Flycut.filewave.recipe
+++ b/Flycut/Flycut.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Flycut</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Flycut.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Flycut.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/FortiClient/FortiClient.filewave.recipe
+++ b/FortiClient/FortiClient.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.FortiClient</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/FortiClient.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/FortiClient.app</string>
 				<key>source_path</key>
 				<string>%pathname%/FortiClientUpdate.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/FortiClient.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/GIMP/GIMP.filewave.recipe
+++ b/GIMP/GIMP.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.GIMP</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/GIMP.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/GIMP.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %full_version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/GIMP.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/GasMask/GasMask.filewave.recipe
+++ b/GasMask/GasMask.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.GasMask</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/GasMask.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/GitHub/GitHubDesktop.filewave.recipe
+++ b/GitHub/GitHubDesktop.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.GitHubDesktop</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/GitHub Desktop.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/GitHub Desktop.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Github/Atom.filewave.recipe
+++ b/Github/Atom.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Atom</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Atom.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Atom.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>

--- a/Go2Shell/Go2Shell.filewave.recipe
+++ b/Go2Shell/Go2Shell.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Go2Shell</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Go2Shell.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Go2Shell.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Go2Shell.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Go2Shell.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/GoldenCheetah/GoldenCheetah.download.recipe
+++ b/GoldenCheetah/GoldenCheetah.download.recipe
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/GoldenCheetah.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>

--- a/GoldenCheetah/GoldenCheetah.filewave.recipe
+++ b/GoldenCheetah/GoldenCheetah.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.GoldenCheetah</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/GoldenCheetah.app</string>
         <key>os</key>
 		<string>dmg</string>
 	</dict>
@@ -35,7 +35,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/GoldenCheetah.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Google/GoogleDrive.filewave.recipe
+++ b/Google/GoogleDrive.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.GoogleDrive</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/GoogleDrive.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Google/WebDesigner.filewave.recipe
+++ b/Google/WebDesigner.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.GoogleWebDesigner</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/GoogleWebDesigner.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/GoogleWebDesigner.app</string>
 				<key>overwrite</key>
 				<true/>
 				<key>source_path</key>
@@ -46,7 +46,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/GoogleWebDesigner.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Handbrake/Handbrake.filewave.recipe
+++ b/Handbrake/Handbrake.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Handbrake</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Handbrake.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Hooper/Principle.filewave.recipe
+++ b/Hooper/Principle.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Principle</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Principle.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Principle.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/IINA/IINA.filewave.recipe
+++ b/IINA/IINA.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.IINA</string>
 		<key>fw_destination_root</key>
-        	<string>/Applications/%NAME%.app</string>
+        	<string>/Applications/IINA.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
                 <key>Arguments</key>
                 <dict>
                         <key>destination_path</key>
-                        <string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+                        <string>%RECIPE_CACHE_DIR%/Applications/IINA.app</string>
                         <key>source_path</key>
                         <string>%pathname%/IINA.app</string>
                 </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/IINA.app</string>
 			</dict>
 			<key>Comment</key>
 			<string>Import the IINA app into FileWave</string>

--- a/Inkscape/Inkscape.filewave.recipe
+++ b/Inkscape/Inkscape.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Inkscape</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Inkscape.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Inkscape.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Inkscape.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/InsomniaX/InsomniaX.filewave.recipe
+++ b/InsomniaX/InsomniaX.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.InsomniaX</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/InsomniaX.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/InstallDiskCreator/InstallDiskCreator.download.recipe
+++ b/InstallDiskCreator/InstallDiskCreator.download.recipe
@@ -38,7 +38,7 @@
                 <key>source</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Install Disk Creator.app</string>
                 <key>target</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/InstallDiskCreator.app</string>
             </dict>
         </dict>
 		<dict>
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/InstallDiskCreator.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -56,7 +56,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/InstallDiskCreator.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "io.macdaddy.Install-Disk-Creator" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8G7S5244GJ")</string>
             </dict>

--- a/InstallDiskCreator/InstallDiskCreator.filewave.recipe
+++ b/InstallDiskCreator/InstallDiskCreator.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.InstallDiskCreator</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/InstallDiskCreator.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/InstallDiskCreator.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Itsycal/Itsycal.filewave.recipe
+++ b/Itsycal/Itsycal.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Itsycal</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Itsycal.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Itsycal.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Itsycal.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.mowglii.ItsycalApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HFT3T55WND)</string>
 			</dict>
@@ -57,7 +57,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Itsycal.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/JetBrains/IDEA-CE.filewave.recipe
+++ b/JetBrains/IDEA-CE.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.IDEA-CE</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/IDEA-CE.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/JetBrains/IDEA-IU.filewave.recipe
+++ b/JetBrains/IDEA-IU.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.IDEA-IU</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/IDEA-IU.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/JetBrains/PhpStorm.filewave.recipe
+++ b/JetBrains/PhpStorm.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.PhpStorm</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/PhpStorm.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/JetBrains/PyCharmPro.filewave.recipe
+++ b/JetBrains/PyCharmPro.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.PyCharmPro</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/PyCharmPro.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/JetBrains/RubyMine.filewave.recipe
+++ b/JetBrains/RubyMine.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.RubyMine</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/RubyMine.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/JetBrains/WebStorm.filewave.recipe
+++ b/JetBrains/WebStorm.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.WebStorm</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/WebStorm.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Kap/Kap.filewave.recipe
+++ b/Kap/Kap.filewave.recipe
@@ -13,7 +13,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Kap</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Kap.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Kap.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Kap.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/KeePassXC/KeePassXC.filewave.recipe
+++ b/KeePassXC/KeePassXC.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.KeePassXC</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/KeePassXC.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -50,7 +50,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>destination_path</key>
-                                <string>%pkgroot%/%NAME%.app</string>
+                                <string>%pkgroot%/KeePassXC.app</string>
                                 <key>source_path</key>
                                 <string>%pathname%/*.app</string>
                         </dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/KeePassXC.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Keybase/Keybase.filewave.recipe
+++ b/Keybase/Keybase.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Keybase</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Keybase.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Keybase.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Keybase.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Kindle/Kindle.filewave.recipe
+++ b/Kindle/Kindle.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Kindle</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Kindle.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>destination_path</key>
-                                <string>%pkgroot%/%NAME%.app</string>
+                                <string>%pkgroot%/Kindle.app</string>
                                 <key>source_path</key>
                                 <string>%pathname%/*.app</string>
                         </dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Kindle.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Kindle.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/LibreOffice/LibreOffice.filewave.recipe
+++ b/LibreOffice/LibreOffice.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.LibreOffice</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/LibreOffice.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/LimeChat/LimeChat.filewave.recipe
+++ b/LimeChat/LimeChat.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.LimeChat</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/LimeChat.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/LimeChat.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/MAMP/MAMP.filewave.recipe
+++ b/MAMP/MAMP.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.MAMP</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/MAMP.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -34,7 +34,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/MAMP.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/MPlayerX/MPlayerX.filewave.recipe
+++ b/MPlayerX/MPlayerX.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.MPlayerX</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/MPlayerX.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -35,7 +35,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/MPlayerX.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/MacDown/MacDown.filewave.recipe
+++ b/MacDown/MacDown.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.MacDown</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/MacDown.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -31,7 +31,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/MacDown.app/Contents/Info.plist</string>
             </dict>
         </dict>
 		<dict>
@@ -46,7 +46,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/MacDown.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/MacPass/MacPass.filewave.recipe
+++ b/MacPass/MacPass.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.MacPass</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/MacPass.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/MacPass.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Mactracker/Mactracker.filewave.recipe
+++ b/Mactracker/Mactracker.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Mactracker</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Mactracker.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Mactracker.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Magewell/Magewell.filewave.recipe
+++ b/Magewell/Magewell.filewave.recipe
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/Magewell USB Capture Utility.app</string>
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/USB_Capture/USBCaptureUtility_%version%Intenal.dmg/*.app</string>
             </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Magewell USB Capture Utility.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Meteorologist/Meteorologist.filewave.recipe
+++ b/Meteorologist/Meteorologist.filewave.recipe
@@ -13,7 +13,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Meteorologist</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Meteorologist.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/Meteorologist.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Meteorologist.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Microsoft/Skype.filewave.recipe
+++ b/Microsoft/Skype.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Skype</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Skype.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Microsoft/VisualStudioCode.filewave.recipe
+++ b/Microsoft/VisualStudioCode.filewave.recipe
@@ -17,7 +17,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.visualstudiocode</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/Visual Studio Code.app</string>
 		</dict>
 		<key>Process</key>
 		<array>

--- a/Microsoft/Yammer.filewave.recipe
+++ b/Microsoft/Yammer.filewave.recipe
@@ -13,7 +13,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.MSYammer</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/Yammer.app</string>
 		</dict>
 		<key>MinimumVersion</key>
 		<string>0.6.1</string>
@@ -48,7 +48,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>destination_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/Yammer.app</string>
 					<key>source_path</key>
 					<string>%pathname%/*.app</string>
 				</dict>
@@ -67,7 +67,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/Yammer.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Mindjet/MindManager.filewave.recipe
+++ b/Mindjet/MindManager.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.MindManager</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Mindjet MindManager.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Mozilla/Firefox.filewave.recipe
+++ b/Mozilla/Firefox.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Firefox</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Firefox.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Mozilla/Thunderbird.filewave.recipe
+++ b/Mozilla/Thunderbird.filewave.recipe
@@ -17,7 +17,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Thunderbird</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Thunderbird.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Mumble/Mumble.filewave.recipe
+++ b/Mumble/Mumble.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Mumble</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Mumble.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,9 +25,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Mumble.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Mumble.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -44,7 +44,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Mumble.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/MusicBrainzPicard/MusicBrainzPicard.filewave.recipe
+++ b/MusicBrainzPicard/MusicBrainzPicard.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.MusicBrainzPicard</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/MusicBrainzPicard.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/MusicBrainzPicard.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%-%version%.dmg/*.app</string>
 			</dict>
@@ -44,7 +44,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/MusicBrainzPicard.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/NetSpot/NetSpot.filewave.recipe
+++ b/NetSpot/NetSpot.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.NetSpot</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/NetSpot.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/NetSpot.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/NetSpot.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/NetSpot.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/ObjectiveDevelopment/LaunchBar.filewave.recipe
+++ b/ObjectiveDevelopment/LaunchBar.filewave.recipe
@@ -13,7 +13,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.LaunchBar</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/LaunchBar.app</string>
 		</dict>
 		<key>MinimumVersion</key>
 		<string>0.6.1</string>
@@ -39,7 +39,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>destination_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/LaunchBar.app</string>
 					<key>source_path</key>
 					<string>%pathname%/*.app</string>
 				</dict>
@@ -58,7 +58,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/LaunchBar.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/OmniGroup/OmniFocus2.filewave.recipe
+++ b/OmniGroup/OmniFocus2.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.OmniFocus2</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/OmniFocus2.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/OmniFocus2.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>OmniFocus - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OmniFocus2.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/OmniGroup/OmniFocus3.filewave.recipe
+++ b/OmniGroup/OmniFocus3.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.OmniFocus3</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/OmniFocus3.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/OmniFocus3.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>OmniFocus - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OmniFocus3.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/OmniGroup/OmniGraffle6.filewave.recipe
+++ b/OmniGroup/OmniGraffle6.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.OmniGraffle6</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/OmniGraffle6.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/OmniGraffle6.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/OmniGraffle6.app</string>
                 <key>requirement</key>
                 <string>certificate leaf = H"26fe998f5ff3bad1beeac952a233231d4e5ad523" and identifier "com.omnigroup.OmniGraffle6"</string>
             </dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
                 <string>OmniGraffle - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OmniGraffle6.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/OmniGroup/OmniGraffle7.filewave.recipe
+++ b/OmniGroup/OmniGraffle7.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.OmniGraffle7</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/OmniGraffle7.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/OmniGraffle7.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/OmniGraffle7.app</string>
                 <key>requirement</key>
                 <string>identifier "com.omnigroup.OmniGraffle7" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
             </dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
                 <string>OmniGraffle - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OmniGraffle7.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Onyx/Onyx.filewave.recipe
+++ b/Onyx/Onyx.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.OnyX</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/OnyX.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/OpenOffice/OpenOffice.filewave.recipe
+++ b/OpenOffice/OpenOffice.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.OpenOffice</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/OpenOffice.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OpenOffice.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/OpenOffice.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/OpenOffice.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OpenOffice.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/OpenShot/OpenShot.filewave.recipe
+++ b/OpenShot/OpenShot.filewave.recipe
@@ -15,7 +15,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.OpenShot</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/OpenShot.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -52,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OpenShot.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -71,7 +71,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/OpenShot.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Opera/Opera.filewave.recipe
+++ b/Opera/Opera.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Opera</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Opera.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>
@@ -55,7 +55,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Oracle/MySQLWorkbench.filewave.recipe
+++ b/Oracle/MySQLWorkbench.filewave.recipe
@@ -37,7 +37,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>destination_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/MySQLWorkbench.app</string>
 					<key>source_path</key>
 					<string>%pathname%/*.app</string>
 				</dict>
@@ -48,7 +48,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_plist_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+					<string>%pkgroot%/Applications/MySQLWorkbench.app/Contents/Info.plist</string>
 				</dict>
 				<key>Processor</key>
 				<string>Versioner</string>
@@ -63,7 +63,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/MySQLWorkbench.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/PDFsam/PDFsam.filewave.recipe
+++ b/PDFsam/PDFsam.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.PDFsam</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/PDFsam.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -52,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/PDFsam.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -71,7 +71,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/PDFsam.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/PaloAlto/GlobalProtectMac.filewave.recipe
+++ b/PaloAlto/GlobalProtectMac.filewave.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/GlobalProtect.app/Contents</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Contents</string>
 			</dict>
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/GlobalProtect.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>

--- a/PingPlotter/PingPlotter.download.recipe
+++ b/PingPlotter/PingPlotter.download.recipe
@@ -38,7 +38,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/PingPlotter.app/Contents/Info.plist</string>
             </dict>
         </dict>
 	</array>

--- a/PingPlotter/PingPlotter.filewave.recipe
+++ b/PingPlotter/PingPlotter.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.PingPlotter</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/PingPlotter.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/PingPlotter.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Platypus/Platypus.filewave.recipe
+++ b/Platypus/Platypus.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Platypus</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Platypus.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/Platypus.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Pock/Pock.filewave.recipe
+++ b/Pock/Pock.filewave.recipe
@@ -17,7 +17,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.Pock</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/Pock.app</string>
 		</dict>
 		<key>Process</key>
 		<array>
@@ -33,7 +33,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/Pock.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/PostgresApp/PostgresApp.filewave.recipe
+++ b/PostgresApp/PostgresApp.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.PostgresApp</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/PostgresApp.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Postman/Postman.filewave.recipe
+++ b/Postman/Postman.filewave.recipe
@@ -17,7 +17,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.Postman</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/Postman.app</string>
 		</dict>
 		<key>Process</key>
 		<array>
@@ -25,7 +25,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_plist_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/Postman.app/Contents/Info.plist</string>
 				</dict>
 				<key>Processor</key>
 				<string>Versioner</string>
@@ -42,7 +42,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/Postman.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Processing/Processing.filewave.recipe
+++ b/Processing/Processing.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Processing</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Processing.app</string>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/ProjectWizards/MerlinProject.filewave.recipe
+++ b/ProjectWizards/MerlinProject.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.MerlinProject</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Merlin Project.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/RagingMenace/MenuMeters.filewave.recipe
+++ b/RagingMenace/MenuMeters.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.MenuMeters</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/MenuMeters.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/MenuMeters.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/MenuMeters.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/RawTherapee/RawTherapee.filewave.recipe
+++ b/RawTherapee/RawTherapee.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.RawTherapee</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/RawTherapee.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/RawTherapee.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/*.app</string>
 			</dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/RawTherapee.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/ScreenFlow/ScreenFlow.filewave.recipe
+++ b/ScreenFlow/ScreenFlow.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.ScreenFlow</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ScreenFlow.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/ScreenFlow5/ScreenFlow.filewave.recipe
+++ b/ScreenFlow5/ScreenFlow.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.ScreenFlow5</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ScreenFlow.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Shotcut/Shotcut.filewave.recipe
+++ b/Shotcut/Shotcut.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Shotcut</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Shotcut.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Shotcut.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Shotcut.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Skitch/Skitch.filewave.recipe
+++ b/Skitch/Skitch.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Skitch</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Skitch.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Skitch.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Skitch.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Slack/Slack.filewave.recipe
+++ b/Slack/Slack.filewave.recipe
@@ -13,7 +13,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Slack</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Slack.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -27,7 +27,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Slack.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Slack.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Snk/Snk.filewave.recipe
+++ b/Snk/Snk.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Snk</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Snk.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Snk.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Snk.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.mowglii.Snk" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HFT3T55WND)</string>
 			</dict>
@@ -57,7 +57,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Snk.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/SublimeText/SublimeText3.filewave.recipe
+++ b/SublimeText/SublimeText3.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.SublimeText3</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Sublime Text.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Sublime Text.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Sublime Text.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Sublime Text.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/SuspiciousPackageApp/SuspiciousPackageApp.filewave.recipe
+++ b/SuspiciousPackageApp/SuspiciousPackageApp.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.SuspiciousPackageApp</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/SuspiciousPackageApp.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/SuspiciousPackageApp.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -67,7 +67,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/SuspiciousPackageApp.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/TagSpaces/TagSpaces.filewave.recipe
+++ b/TagSpaces/TagSpaces.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.TagSpaces</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/TagSpaces.app</string>
         <key>os</key>
 		<string>osx64</string>
 	</dict>
@@ -35,7 +35,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/TagSpaces.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/TeXstudio/TeXstudio.filewave.recipe
+++ b/TeXstudio/TeXstudio.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TeXstudio</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TeXstudio.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/TeXstudio.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/TeamSpeak/TeamSpeak.filewave.recipe
+++ b/TeamSpeak/TeamSpeak.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TeamSpeak</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TeamSpeak.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/TeamSpeak.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/TeamSpeak.app</string>
 				<key>requirement</key>
 				<string>identifier "com.teamspeak.TeamSpeak3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "969E37EL53"</string>
 			</dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/TeamSpeak.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/TeamViewer/TeamViewer.filewave.recipe
+++ b/TeamViewer/TeamViewer.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TeamViewer</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TeamViewer.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/root/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/payload/root/Applications/TeamViewer.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -77,7 +77,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/payload/root/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/payload/root/Applications/TeamViewer.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Telegram/Telegram.filewave.recipe
+++ b/Telegram/Telegram.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Telegram</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Telegram.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Telegram.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Telegram.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -59,7 +59,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Telegram.app</string>
 				<key>requirement</key>
 				<string>identifier "com.tdesktop.Telegram" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "63FLR8MQA9"</string>
 			</dict>
@@ -78,7 +78,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Telegram.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Telestream/ScreenFlow.filewave.recipe
+++ b/Telestream/ScreenFlow.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.ScreenFlow</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ScreenFlow.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -41,9 +41,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/ScreenFlow.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/ScreenFlow.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -60,7 +60,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/ScreenFlow.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.johncclayton.filewave.FWTool/FileWaveImporter</string>

--- a/TheUnarchiver/TheUnarchiver.filewave.recipe
+++ b/TheUnarchiver/TheUnarchiver.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TheUnarchiver</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TheUnarchiver.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Thonny/Thonny.filewave.recipe
+++ b/Thonny/Thonny.filewave.recipe
@@ -18,7 +18,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Thonny</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Thonny.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -41,7 +41,7 @@
 		<key>Arguments</key>
 		<dict>
 			<key>destination_path</key>
-			<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+			<string>%RECIPE_CACHE_DIR%/Thonny.app</string>
 			<key>source_path</key>
 			<string>%pathname%/*.app</string>
 		</dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/Thonny.app/Contents/Info.plist</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Thonny.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/TimeMachineEditor/TimeMachineEditor.filewave.recipe
+++ b/TimeMachineEditor/TimeMachineEditor.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TimeMachineEditor</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TimeMachineEditor.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Tor/TorBrowser.filewave.recipe
+++ b/Tor/TorBrowser.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TorBrowserBundle</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TorBrowser.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -41,9 +41,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/TorBrowser.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/TorBrowser.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -60,7 +60,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% %LANGUAGE% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/TorBrowser.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Tor/TorMessenger.filewave.recipe
+++ b/Tor/TorMessenger.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.TorMessenger</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/TorMessenger.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -61,9 +61,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/TorMessenger.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/TorMessenger.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -80,7 +80,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% %LANGUAGE% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/TorMessenger.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Tunnelblick/Tunnelblick.filewave.recipe
+++ b/Tunnelblick/Tunnelblick.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.Tunnelblick</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Tunnelblick.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Tunnelblick.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -44,7 +44,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Tunnelblick.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/UNetbootin/UNetbootin.filewave.recipe
+++ b/UNetbootin/UNetbootin.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.UNetbootin</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/UNetbootin.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/UNetbootin.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/UNetbootin.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/UnRarX/UnRarX.filewave.recipe
+++ b/UnRarX/UnRarX.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.UnRarX</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/UnRarX.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -37,7 +37,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/UnRarX.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Usage/Usage.download.recipe
+++ b/Usage/Usage.download.recipe
@@ -58,7 +58,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Usage.app/Contents/Info.plist</string>
             </dict>
         </dict>
 		<dict>
@@ -67,7 +67,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Usage.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.mediaatelier.Usage" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2295B9BX7F")</string>
 			</dict>

--- a/Usage/Usage.filewave.recipe
+++ b/Usage/Usage.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Usage</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Usage.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Usage.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/VLC/VLC.filewave.recipe
+++ b/VLC/VLC.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.VLC</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/VLC.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/VMware/VMwareFusion.filewave.recipe
+++ b/VMware/VMwareFusion.filewave.recipe
@@ -17,7 +17,7 @@
         	<key>fw_app_bundle_id</key>
         	<string>com.github.peshay.filewave.VMwareFusion</string>
         	<key>fw_destination_root</key>
-        	<string>/Applications/%NAME%.app</string>
+        	<string>/Applications/VMwareFusion.app</string>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/VOX/VOX.filewave.recipe
+++ b/VOX/VOX.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.VOX</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/VOX.app</string>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/VSCodium/VSCodium.filewave.recipe
+++ b/VSCodium/VSCodium.filewave.recipe
@@ -13,7 +13,7 @@
 			<key>fw_app_bundle_id</key>
 			<string>com.github.peshay.filewave.VSCodium</string>
 			<key>fw_destination_root</key>
-			<string>/Applications/%NAME%.app</string>
+			<string>/Applications/VSCodium.app</string>
 		</dict>
 		<key>MinimumVersion</key>
 		<string>0.6.1</string>
@@ -37,7 +37,7 @@
 					<key>fw_fileset_name</key>
 					<string>%NAME% - %version%</string>
 					<key>fw_import_source</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/VSCodium.app</string>
 				</dict>
 				<key>Processor</key>
 				<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Vagrant/VagrantManager.filewave.recipe
+++ b/Vagrant/VagrantManager.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.VagrantManager</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/VagrantManager.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/VagrantManager.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
                 <string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/VagrantManager.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/VirtualBox/VirtualBox.filewave.recipe
+++ b/VirtualBox/VirtualBox.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.VirtualBox</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/VirtualBox.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/WhatsApp/WhatsApp.filewave.recipe
+++ b/WhatsApp/WhatsApp.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.WhatsApp</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/WhatsApp.app</string>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/Wireshark/Wireshark.filewave.recipe
+++ b/Wireshark/Wireshark.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Wireshark</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/Wireshark.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.pkg.unpacked/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.pkg.unpacked/Wireshark.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -79,7 +79,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.pkg.unpacked/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.pkg.unpacked/Wireshark.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/X-Mirage/X-Mirage.filewave.recipe
+++ b/X-Mirage/X-Mirage.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.X-Mirage</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/X-Mirage.app</string>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/XMind8/XMind8.filewave.recipe
+++ b/XMind8/XMind8.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.XMind8</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/XMind 8.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/XMind 8.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -71,7 +71,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/XMind 8.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Xmind/XMind.download.recipe
+++ b/Xmind/XMind.download.recipe
@@ -36,7 +36,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pathname%/XMind.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/XMind.app</string>
                 <key>requirement</key>
                 <string>identifier "org.xmind.cathy.application" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4WV38P2X5K"</string>
             </dict>

--- a/Xmind/XMind.filewave.recipe
+++ b/Xmind/XMind.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.XMind</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/XMind.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -41,9 +41,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/XMind.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/XMind.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -60,7 +60,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% %version% (v%version2%)</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/XMind.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/XtraFinder/XtraFinder.filewave.recipe
+++ b/XtraFinder/XtraFinder.filewave.recipe
@@ -13,7 +13,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.XtraFinder</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/XtraFinder.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/%NAME%.app</string>
+                <string>%pkgroot%/XtraFinder.app</string>
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
             </dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/XtraFinder.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/YourKit/JavaProfiler.filewave.recipe
+++ b/YourKit/JavaProfiler.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.JavaProfiler</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/YourKit-Java-Profiler.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/YourKit-Java-Profiler.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version% - %build%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/YourKit-Java-Profiler.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/cdto/cdto.filewave.recipe
+++ b/cdto/cdto.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.cdto</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/cdto.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/coconut Battery/coconutBattery.filewave.recipe
+++ b/coconut Battery/coconutBattery.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.coconutBattery</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/coconutBattery.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -33,7 +33,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/coconutBattery.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/drawio/draw.io.filewave.recipe
+++ b/drawio/draw.io.filewave.recipe
@@ -15,7 +15,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.peshay.filewave.draw.io</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/draw.io Desktop.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -41,7 +41,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/draw.io Desktop.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -60,7 +60,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/draw.io Desktop.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/dupeGuru/dupeGuru.filewave.recipe
+++ b/dupeGuru/dupeGuru.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.dupeGuru</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/dupeGuru.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/dupeGuru.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/dupeGuru.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/iTerm2/iTerm2.filewave.recipe
+++ b/iTerm2/iTerm2.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.iTerm2</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/iTerm.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/jEdit/jEdit.filewave.recipe
+++ b/jEdit/jEdit.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.jEdit</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/jEdit.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/keystore-explorer/keystore-explorer.filewave.recipe
+++ b/keystore-explorer/keystore-explorer.filewave.recipe
@@ -15,7 +15,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.keystore-explorer</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/KeyStore Explorer.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -41,7 +41,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/KeyStore Explorer.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -60,7 +60,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/KeyStore Explorer.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/miro/miro.filewave.recipe
+++ b/miro/miro.filewave.recipe
@@ -54,7 +54,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/miro.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -65,7 +65,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>input_plist_path</key>
-                    <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                    <string>%pkgroot%/miro.app/Contents/Info.plist</string>
                 </dict>
                 <key>Processor</key>
                 <string>Versioner</string>
@@ -82,7 +82,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/miro.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/nvALT/nvALT.filewave.recipe
+++ b/nvALT/nvALT.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.nvALT</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/nvALT.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +29,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/nvALT.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
@@ -46,7 +46,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/nvALT.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.