### PR TITLE
Rework of the regex of the URLTextSearch for MindManager Mac

### DIFF
--- a/Mindjet/MindManager.download.recipe
+++ b/Mindjet/MindManager.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://www.mindjet.com/support-info/download-library</string>
                 <key>re_pattern</key>
-                <string>Build ([^"]*)\) .*"https://www.mindjet.com/mm-mac-dmg</string>
+                <string>Build ([^"]*)\).{1,30}"https://www.mindjet.com/mm-mac-dmg</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
             </dict>


### PR DESCRIPTION
At the moment the regex just looks for any build and a href to a mac download link, but after downloading the website with curl there are no newlines and the match is found over multiple lines. Therefore instead of looking for the starting point and end point with infinite characters in between, it now does look for the two points but only allows a finite number of characters to really only find a MacOS release.