### PR TITLE
Basic python3 compatibility

### DIFF
--- a/OxygenXML/OxygenURLProvider.py
+++ b/OxygenXML/OxygenURLProvider.py
@@ -80,12 +80,11 @@ class OxygenURLProvider(Processor):
     }
 
     def main(self):
-        valid_prods = URLS.keys()
         prod = self.env.get("product_name")
-        if prod not in valid_prods:
+        if prod not in URLS:
             raise ProcessorError(
                 "product_name %s is invalid; it must be one of: %s"
-                % (prod, valid_prods))
+                % (prod, ', '.join(URLS)))
         url = URLS[prod]
         valid_plats = PLATS
         plat = self.env.get("platform_name")

--- a/OxygenXML/OxygenURLProvider.py
+++ b/OxygenXML/OxygenURLProvider.py
@@ -18,10 +18,14 @@
 # pylint: disable=e1101
 
 from __future__ import absolute_import
-import urllib2
 import re
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["OxygenURLProvider"]
 
@@ -93,7 +97,7 @@ class OxygenURLProvider(Processor):
                 "platform_name %s is invalid; it must be one of: %s"
                 % (plat, valid_plats))
         try:
-            self.env["object"] = urllib2.urlopen(url).read()
+            self.env["object"] = urlopen(url).read()
         except BaseException as err:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" % err)

--- a/OxygenXML/OxygenURLProvider.py
+++ b/OxygenXML/OxygenURLProvider.py
@@ -18,7 +18,10 @@
 # pylint: disable=e1101
 
 from __future__ import absolute_import
+
 import re
+import ssl
+from functools import wraps
 
 from autopkglib import Processor, ProcessorError
 
@@ -37,8 +40,6 @@ URLS = {"Editor": "https://www.oxygenxml.com/xml_editor/download_oxygenxml_edito
 
 PLATS = ['Windows64', 'MacOSX', 'Linux64', 'All', 'Eclipse']
 
-import ssl
-from functools import wraps
 
 
 def sslwrap(func):

--- a/OxygenXML/OxygenURLProvider.py
+++ b/OxygenXML/OxygenURLProvider.py
@@ -136,7 +136,7 @@ class OxygenURLProvider(Processor):
                 download_url = ("http://mirror.oxygenxml.com/InstData/%s/%s/VM/oxygen%s.tar.gz" % (prod, plat, prod))
 
         self.env["url"] = download_url
-        self.env["filename"] = re.search('/([0-9a-zA-Z-_.]*$)', download_url).group(1)
+        self.env["filename"] = re.search(r'/([0-9a-zA-Z-_.]*$)', download_url).group(1)
         self.output("Found Version %s" % self.env["version"])
         self.output("Found Build id %s" % self.env["buildid"])
         self.output("Use URL %s" % self.env["url"])

--- a/OxygenXML/OxygenURLProvider.py
+++ b/OxygenXML/OxygenURLProvider.py
@@ -17,6 +17,7 @@
 # suppress 'missing class member env'
 # pylint: disable=e1101
 
+from __future__ import absolute_import
 import urllib2
 import re
 

--- a/Xmind/XMindURLProvider.py
+++ b/Xmind/XMindURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Xmind/XMindURLProvider.py
+++ b/Xmind/XMindURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Xmind/XMindURLProvider.py
+++ b/Xmind/XMindURLProvider.py
@@ -16,10 +16,13 @@
 
 from __future__ import absolute_import
 import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["XMindUrlProvider"]
 
@@ -50,7 +53,7 @@ class XMindURLProvider(Processor):
 
     def get_xmind_url(self, base_url):
         try:
-            url = urllib2.urlopen(base_url).read()
+            url = urlopen(base_url).read()
             return url
 
         except BaseException as err:


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.