### PR TITLE
Update MindManager download URL

### DIFF
--- a/Mindjet/MindManager.download.recipe
+++ b/Mindjet/MindManager.download.recipe
@@ -16,30 +16,19 @@
     <key>Process</key>
     <array>
     	<dict>
-        	<key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://www.mindjet.com/support-info/download-library</string>
-                <key>re_pattern</key>
-                <string>Build ([0-9]+.[0-9]+.[0-9]+).*mm-mac-dmg</string>
-                <key>result_output_var_name</key>
-                <string>version</string>
-            </dict>
-        </dict>
-    	<dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://download.mindjet.com/MindManager_Mac_%version%.dmg</string>
-		<key>request_headers</key>
+                <string>https://www.mindmanager.com/mm-mac-dmg</string>
+		        <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/601.1.39 (KHTML, like Gecko) Version/9.0 Safari/601.1.39</string>
                 </dict>
+                <key>prefetch_filename</key>
+                <true/>
             </dict>
         </dict>
 	<dict>


### PR DESCRIPTION
Mindjet seems to be using a single URL that looks like it will always point to the most recent version of the download. This URL redirects to the latest download, so I've added the `prefetch_filename` argument for URLDownloader to make sure the dmg is correctly named.