### PR TITLE
change url for mindmanager to link for newest Mindmanager version

### DIFF
--- a/Mindjet/MindManager.download.recipe
+++ b/Mindjet/MindManager.download.recipe
@@ -10,31 +10,22 @@
     <dict>
         <key>NAME</key>
         <string>Mindjet MindManager</string> 
+        <key>URL</key>
+        <string>https://www.mindmanager.com/mm-mac-dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>
     <key>Process</key>
     <array>
     	<dict>
-        	<key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://www.mindjet.com/support-info/download-library</string>
-                <key>re_pattern</key>
-                <string>Build ([0-9]+.[0-9]+.[0-9]+).*mm-mac-dmg</string>
-                <key>result_output_var_name</key>
-                <string>version</string>
-            </dict>
-        </dict>
-    	<dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://download.mindjet.com/MindManager_Mac_%version%.dmg</string>
+                <string>https://www.mindmanager.com/mm-mac-dmg</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
 		<key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
@@ -48,7 +39,7 @@
 	    <key>Arguments</key>
 	    <dict>
 	        <key>input_path</key>
-	        <string>%pathname%/*.app</string>
+	        <string>%pathname%/MindManager.app</string>
 	        <key>requirement</key>
 	        <string>identifier "com.mindjet.mindmanager.13" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF6ZZ779N5</string>
 	    </dict>


### PR DESCRIPTION
The old Url for Mindmanager was invalid. The url https://www.mindmanager.com/mm-mac-dmg fits as Download link to the newest version of Mindmanager. 

Output of running `autopkg run -vv com.github.peshay.download.MindManager`:
```
Processing com.github.peshay.download.MindManager...
WARNING: com.github.peshay.download.MindManager is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Mindjet MindManager.dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11) '
                                             'AppleWebKit/601.1.39 (KHTML, '
                                             'like Gecko) Version/9.0 '
                                             'Safari/601.1.39'},
           'url': 'https://www.mindmanager.com/mm-mac-dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Sep 2020 19:02:14 GMT
URLDownloader: Storing new ETag header: "cd71bd49d96827f0aac2e675c80e862c-11"
URLDownloader: Downloaded /Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/Mindjet MindManager.dmg
{'Output': {'download_changed': True,
            'etag': '"cd71bd49d96827f0aac2e675c80e862c-11"',
            'last_modified': 'Mon, 21 Sep 2020 19:02:14 GMT',
            'pathname': '/Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/Mindjet '
                        'MindManager.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/Mindjet '
                                                                        'MindManager.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/Mindjet '
                         'MindManager.dmg/MindManager.app',
           'requirement': 'identifier "com.mindjet.mindmanager.13" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'ZF6ZZ779N5'}}
CodeSignatureVerifier: Mounted disk image /Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/Mindjet MindManager.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.SDWGNE/MindManager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SDWGNE/MindManager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SDWGNE/MindManager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/receipts/com.github.peshay.download-receipt-20200928-152225.plist

The following new items were downloaded:
    Download Path                                                                                                    
    -------------                                                                                                    
    /Users/timkeller/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/Mindjet MindManager.dmg 
```