### PR TITLE
Remove DISABLE_CODE_SIGNATURE_VERIFICATION input variable

### DIFF
--- a/Mozilla/Thunderbird.filewave.recipe
+++ b/Mozilla/Thunderbird.filewave.recipe
@@ -12,8 +12,6 @@
 		<string>en-US</string>
 		<key>NAME</key>
 		<string>Thunderbird</string>
-		<key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        	<true/>
 		<key>fw_app_bundle_id</key>
 		<string>com.github.peshay.filewave.Thunderbird</string>
 		<key>fw_destination_root</key>


### PR DESCRIPTION
There's no CodeSignatureVerifier processor in this recipe, so this input variable has no effect.