### PR TITLE
Update Mattermost.download.recipe

### DIFF
--- a/Mattermost/Mattermost.download.recipe
+++ b/Mattermost/Mattermost.download.recipe
@@ -12,19 +12,20 @@
 		<string>Mattermost</string>
 		
 <!--SELECT YOUR OS VERSION AND INPUT BELOW
-	"mac" for MAC OS X
+	"mac" for macOS Intel
+	"mac-m1" for macOS Apple Silicon
 	"win" for WINDOWS EXE
 	"x64" for WINDOWS 64 BIT MSI
-	"x32" for WINDOWS 32 BIT MSI
+	"x86" for WINDOWS 32 BIT MSI
 	"linux-ia32" for LINUX 32 BIT
 	"linux-x64" for LINUX 64 BIT
 -->
 
-		<key>os</key>
-		<string>mac</string><!-- <<<<<< INPUT HERE <<<<<< -->
+	<key>os</key>
+	<string>mac</string><!-- <<<<<< INPUT HERE <<<<<< -->
 	</dict>
 	<key>MinimumVersion</key>
-    <string>0.6.1</string>
+    	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
         <dict>
@@ -33,7 +34,7 @@
                         <key>github_repo</key>
                         <string>mattermost/desktop</string>
                         <key>asset_regex</key>
-                        <string>(mattermost-desktop-[^"]*-%os%.[^"]*)</string>
+                        <string>(mattermost-desktop-[^"]*-%os%\.[^"]*)</string>
                 </dict>
                         <key>Processor</key>
                         <string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Added new text to show Apple Silicon release and corrected Windows 32-bit downloader to be x86, not x32 as before.

Updated regex string to allow for differentiation between Intel and Apple Silicon downloads.

There are still issues here, due to the naming conventions I think the x64 Windows download will pick the zip file, not the msi as you might be intending.