### PR TITLE
Update draw.io.download.recipe

### DIFF
--- a/drawio/draw.io.download.recipe
+++ b/drawio/draw.io.download.recipe
@@ -24,7 +24,7 @@
           		<key>github_repo</key>
           		<string>jgraph/drawio-desktop</string>
           		<key>asset_regex</key>
-          		<string>(draw.io-[^"]*.%os%)</string>
+          		<string>(draw.io-x64-.*?\.dmg)$</string>
         	</dict>
         		<key>Processor</key>
         		<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Updated regex to download intel dmg and not arm.