### PR TITLE
update Mindmanager code signature requirement

### DIFF
--- a/Mindjet/MindManager.download.recipe
+++ b/Mindjet/MindManager.download.recipe
@@ -39,7 +39,7 @@
 	        <key>input_path</key>
 	        <string>%pathname%/*.app</string>
 	        <key>requirement</key>
-	        <string>identifier "com.mindjet.mindmanager.13" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF6ZZ779N5</string>
+	        <string>identifier "com.mindjet.mindmanager.14" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF6ZZ779N5</string>
 	    </dict>
 	</dict>
         <dict>


### PR DESCRIPTION
The old identifier caused a failure of the download recipe. 

The output of `autopkg run -vv com.github.peshay.download.MindManager`:
```
Processing com.github.peshay.download.MindManager...
WARNING: com.github.peshay.download.MindManager is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'prefetch_filename': True,
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11) '
                                             'AppleWebKit/601.1.39 (KHTML, '
                                             'like Gecko) Version/9.0 '
                                             'Safari/601.1.39'},
           'url': 'https://www.mindmanager.com/mm-mac-dmg'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Filename prefetched from the HTTP Location header: MindManager_Mac_14.0.178.dmg
URLDownloader: Storing new Last-Modified header: Thu, 11 Nov 2021 22:55:39 GMT
URLDownloader: Storing new ETag header: "5f7239563193fc505bb3d29bd17ee938-11"
URLDownloader: Downloaded /Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/MindManager_Mac_14.0.178.dmg
{'Output': {'download_changed': True,
            'etag': '"5f7239563193fc505bb3d29bd17ee938-11"',
            'last_modified': 'Thu, 11 Nov 2021 22:55:39 GMT',
            'pathname': '/Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/MindManager_Mac_14.0.178.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/MindManager_Mac_14.0.178.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/MindManager_Mac_14.0.178.dmg/*.app',
           'requirement': 'identifier "com.mindjet.mindmanager.14" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'ZF6ZZ779N5'}}
CodeSignatureVerifier: Mounted disk image /Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/MindManager_Mac_14.0.178.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.xqv6nc/MindManager.app' matched from globbed '/private/tmp/dmg.xqv6nc/*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.xqv6nc/MindManager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.xqv6nc/MindManager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.xqv6nc/MindManager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/receipts/com.github.peshay.download-receipt-20211119-133159.plist

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    /Users/user/Library/AutoPkg/Cache/com.github.peshay.download.MindManager/downloads/MindManager_Mac_14.0.178.dmg  
```