### PR TITLE
Update MindManager.download with latest bundle ID

### DIFF
--- a/Mindjet/MindManager.download.recipe
+++ b/Mindjet/MindManager.download.recipe
@@ -39,7 +39,7 @@
 	        <key>input_path</key>
 	        <string>%pathname%/*.app</string>
 	        <key>requirement</key>
-	        <string>identifier "com.mindjet.mindmanager.14" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF6ZZ779N5</string>
+	        <string>identifier "com.mindjet.mindmanager.22" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF6ZZ779N5</string>
 	    </dict>
 	</dict>
         <dict>


### PR DESCRIPTION
The signing identifier for MindManager changed the middle of last week from "com.mindjet.mindmanager.14" to "com.mindjet.mindmanager.22" - output from codesign locally:

❯ identifier "com.mindjet.mindmanager.22" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF6ZZ779N5

This PR updates the codesign requirement.