### PR TITLE
Update Platypus.download.recipe

### DIFF
--- a/Platypus/Platypus.download.recipe
+++ b/Platypus/Platypus.download.recipe
@@ -24,6 +24,8 @@
                 <string>sveinbjornt/Platypus</string>
                 <key>include_prereleases</key>
                 <string>%PRERELEASE%</string>
+                <key>asset_regex</key>
+                <string>platypus[0-9]*\.[0-9]+\.zip</string>
             </dict>
         </dict>
         <dict>
@@ -39,15 +41,17 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Platypus.app</string>
+                <key>deep_verification</key>
+                <false/>
                 <key>requirement</key>
-                <string>identifier "org.sveinbjorn.Platypus" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: sveinbjornt@gmail.com (55GP2M789L)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+                <string>anchor apple generic and identifier "org.sveinbjorn.Platypus" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5WX26Y89JP")</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi, @peshay 

This PR contains 

- Updated `asset_regex`
- Updated `requirement` for `CodeSignatureVerifier`
- Sets `deep_verification` to False to stop the embedded Sparkle.framework from being picked up and failing the run

Very Verbose Output:
```
autopkg run -vv /Users/paul/Documents/GitHub/peshay-recipes/Platypus/Platypus.download.recipe 
Processing /Users/paul/Documents/GitHub/peshay-recipes/Platypus/Platypus.download.recipe...
WARNING: /Users/paul/Documents/GitHub/peshay-recipes/Platypus/Platypus.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
Use of undefined key in variable substitution: 'PRERELEASE'
{'Input': {'asset_regex': 'platypus[0-9]*\\.[0-9]+\\.zip',
           'github_repo': 'sveinbjornt/Platypus',
           'include_prereleases': '%PRERELEASE%'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'platypus[0-9]*\.[0-9]+\.zip' among asset(s): platypus5.4.src.zip, platypus5.4.zip
GitHubReleasesInfoProvider: Selected asset 'platypus5.4.zip' from release '5.4'
{'Output': {'asset_url': 'https://api.github.com/repos/sveinbjornt/Platypus/releases/assets/76782023',
            'release_notes': '* Added native support for arm64 CPU '
                             'architecture. Both Platypus and the apps it '
                             'generates are now Universal ARM/Intel 64-bit '
                             'binaries\r\n'
                             '* New application icon\r\n'
                             '* Status Menu submenu items can now be disabled '
                             'with the DISABLED syntax\r\n'
                             '* Support relative interpreter path (i.e. '
                             'relative to Resources directory)\r\n'
                             '* Support dark mode for text fields (inverts '
                             'colors, changes dynamically when user switches '
                             'interface modes)\r\n'
                             '* Command line tool no longer defaults to '
                             'stripping nib file (requires explicit -y '
                             'option)\r\n'
                             '* Enabled close button on windows, which now '
                             'quit the app(s)\r\n'
                             '* Added standard Help Menu to ScriptExec apps '
                             '(support for bundled help bundles)\r\n'
                             '* Added support for dynamically changing status '
                             'item title and icon via STATUSTITLE and '
                             'STATUSICON syntax\r\n'
                             '* Warn when non-existent file in bundled files '
                             'list\r\n'
                             '* Command line tool now defaults to creating '
                             'apps with no application icon\r\n'
                             '* Support for notifications is now an option, to '
                             'prevent permission popups on Catalina and '
                             'later\r\n'
                             '* Added Python 3 and Dart interpreter presets\r\n'
                             '* Platypus apps now hide (instead of disabling) '
                             "Open and Open Recent menu items if they don't "
                             'accept files\r\n'
                             '* Fixed issue with signing generated apps due to '
                             'missing "APPL" CFBundleType\r\n'
                             '* Fixed nasty empty newline parsing bug\r\n'
                             '* Switched over to AGIconFamily for icon '
                             'generation, reducing dependence on deprecated '
                             'Carbon calls\r\n'
                             '* Resolved issue with text selection and dark '
                             'mode in generated apps\r\n'
                             '* Improved drag and drop handling on Platypus '
                             'main window\r\n'
                             '* Platypus now requires macOS 10.11 or later\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/sveinbjornt/Platypus/compare/5.3...v5.4',
            'url': 'https://github.com/sveinbjornt/Platypus/releases/download/v5.4/platypus5.4.zip',
            'version': '5.4'}}
URLDownloader
{'Input': {'url': 'https://github.com/sveinbjornt/Platypus/releases/download/v5.4/platypus5.4.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 03 Sep 2022 20:07:11 GMT
URLDownloader: Storing new ETag header: "0x8DA8DE7E32C6CA0"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/downloads/platypus5.4.zip
{'Output': {'download_changed': True,
            'etag': '"0x8DA8DE7E32C6CA0"',
            'last_modified': 'Sat, 03 Sep 2022 20:07:11 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/downloads/platypus5.4.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/downloads/platypus5.4.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename platypus5.4.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/downloads/platypus5.4.zip to /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/Platypus
{'Output': {}}
CodeSignatureVerifier
{'Input': {'deep_verification': False,
           'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/Platypus/Platypus.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.sveinbjorn.Platypus" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5WX26Y89JP")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification disabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/Platypus/Platypus.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/Platypus/Platypus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/Platypus/Platypus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/receipts/Platypus.download-receipt-20220912-132259.plist

The following new items were downloaded:
    Download Path                                                                                    
    -------------                                                                                    
    /Users/paul/Library/AutoPkg/Cache/com.github.peshay.download.Platypus/downloads/platypus5.4.zip
```

Thanks!
Paul 
