### PR TITLE
Fixing extra dict tags and spacing.

### DIFF
--- a/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
@@ -20,13 +20,11 @@
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
-                <key>filename</key>
+				<key>user-agent</key>
+				<string>%USER_AGENT%</string>
+				<key>filename</key>
 				<string>%NAME%.exe</string>
-                <key>url</key>
+				<key>url</key>
 				<string>https://prod-rel-ffc-ccm.oobesaas.adobe.com/adobe-ffc-external/core/v1/wam/download?sapCode=KCCC&amp;productName=CreativeCloud&amp;os=win</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
Suggested fix for recipe, which is causing errors for us: 

WARNING: plist error for /Users/sysman/Library/AutoPkg/RecipeRepos/com.github.autopkg.peshay-recipes/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe: unexpected element at line 23