### PR TITLE
Fix plist syntax

### DIFF
--- a/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Adobe Creative Cloud.</string> 
+	<string>Downloads the latest version of Adobe Creative Cloud.</string>
 	<key>Identifier</key>
 	<string>com.github.peshay.download.Adobe-Creative-Cloud-Win</string>
 	<key>Input</key>
@@ -16,19 +16,17 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
-                <key>filename</key>
+				<key>filename</key>
 				<string>%NAME%.exe</string>
-                <key>url</key>
+				<key>url</key>
 				<string>https://prod-rel-ffc-ccm.oobesaas.adobe.com/adobe-ffc-external/core/v1/wam/download?sapCode=KCCC&amp;productName=CreativeCloud&amp;os=win</string>
+				<key>user-agent</key>
+				<string>%USER_AGENT%</string>
 			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
A recent change to this recipe has made it unable to be parsed by Python, which could break AutoPkg recipe runs for AutoPkg users even if the recipe is not included in the run.

```
Recipe: repos/autopkg/peshay-recipes/Adobe/AdobeCreativeCloudInstaller-Win.download.recipe
Traceback (most recent call last):
  File "~/Desktop/test.py", line 11, in <module>
    recipe_dict = plistlib.load(openfile)
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/plistlib.py", line 875, in load
    return p.parse(fp)
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/plistlib.py", line 177, in parse
    self.parser.ParseFile(fileobj)
  File "/Users/sysadmin/build/v3.10.2/Modules/pyexpat.c", line 416, in StartElement
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/plistlib.py", line 190, in handle_begin_element
    handler(attrs)
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/plistlib.py", line 225, in begin_dict
    self.add_object(d)
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/plistlib.py", line 212, in add_object
    raise ValueError("unexpected element at line %d" %
ValueError: unexpected element at line 23
```
