### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Bluefish/Bluefish.download.recipe
+++ b/Bluefish/Bluefish.download.recipe
@@ -27,7 +27,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.bennewitz.com/bluefish/stable/binaries/%os%/?C=M;O=D</string>
+                <string>https://www.bennewitz.com/bluefish/stable/binaries/%os%/?C=M;O=D</string>
                 <key>re_pattern</key>
                 <string>href="(?P&lt;match&gt;Bluefish-[^"]*[.exe|.dmg])"</string>
                 <key>re_flags</key>

--- a/MTR/MTR.download.recipe
+++ b/MTR/MTR.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://rudix.org/packages/mtr.html</string>
+                <string>https://rudix.org/packages/mtr.html</string>
                 <key>re_pattern</key>
                 <string>https://raw.githubusercontent.com/rudix-mac/packages/master/[^"]*/mtr-([0-9]+.[0-9]+)-[^"]*.pkg"</string>
                 <key>re_flags</key>
@@ -38,7 +38,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://rudix.org/packages/mtr.html</string>
+                <string>https://rudix.org/packages/mtr.html</string>
                 <key>re_pattern</key>
                 <string>href="(https://raw.githubusercontent.com/rudix-mac/packages/master/[^"]*/mtr-%version%-[0-9]+.pkg)"</string>
                 <key>re_flags</key>

--- a/Mindjet/MindManagerWin.download.recipe
+++ b/Mindjet/MindManagerWin.download.recipe
@@ -42,7 +42,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://download.mindjet.com/MindManager_%version%.exe</string>
+                <string>https://download.mindjet.com/MindManager_%version%.exe</string>
             </dict>
         </dict>
         <dict>

--- a/Oracle/JavaCryptographyExtension.download.recipe
+++ b/Oracle/JavaCryptographyExtension.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>url</key>
-		<string>http://www.oracle.com/technetwork/java/javase/downloads/index.html</string>
+		<string>https://www.oracle.com/technetwork/java/javase/downloads/index.html</string>
         <key>ORACLE_LICENSE_COOKIE</key>
         <string>oraclelicense=accept-securebackup-cookie</string>
 	</dict>

--- a/X-Mirage/X-Mirage.download.recipe
+++ b/X-Mirage/X-Mirage.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>X-Mirage</string>
 		<key>DOWNLOAD_URL</key>
-		<string>http://dl.x-mirage.com/x-mirage.dmg</string>
+		<string>https://dl.x-mirage.com/x-mirage.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/jEdit/jEdit.download.recipe
+++ b/jEdit/jEdit.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.jedit.org/index.php?page=download</string>
+                <string>https://www.jedit.org/index.php?page=download</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>re_pattern</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!