### PR TITLE
Change parent recipes for Slack and VSCode filewave recipes

### DIFF
--- a/Microsoft/VisualStudioCode.filewave.recipe
+++ b/Microsoft/VisualStudioCode.filewave.recipe
@@ -9,7 +9,7 @@
 		<key>MinimumVersion</key>
 		<string>0.2.0</string>
 		<key>ParentRecipe</key>
-		<string>com.github.killahquam.download.visualstudiocode</string>
+		<string>com.github.valdore86.download.visualstudiocode</string>
 		<key>Input</key>
 		<dict>
 			<key>NAME</key>

--- a/Slack/Slack.filewave.recipe
+++ b/Slack/Slack.filewave.recipe
@@ -18,7 +18,7 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.killahquam.download.slack</string>
+	<string>com.github.kevinmcox.download.Slack-dmg</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -27,7 +27,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Slack.app/Contents/Info.plist</string>
+                <string>%pathname%/Slack.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -42,7 +42,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Slack.app</string>
+                <string>%pathname%/Slack.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See [this issue](https://github.com/autopkg/killahquam-recipes/issues/28) for details.)

This pull request adjusts the pull requests for two recipes that reference parent recipes in killahquam-recipes. The parent recipes have been changed to point to actively maintained recipes in other repos.