### PR TITLE
Deprecate arm64-specific VSCode recipes

### DIFF
--- a/Microsoft/VisualStudioCode-arm64.download.recipe
+++ b/Microsoft/VisualStudioCode-arm64.download.recipe
@@ -19,6 +19,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This arm64-specific Visual Studio Code recipe is deprecated and will be removed in the future. Please switch to the VSCode recipes in the valdore86-recipes repository, which are Universal (supporting both Intel and Apple Silicon).</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The [VisualStudioCode recipes in valdore86-recipes](https://github.com/autopkg/valdore86-recipes/blob/master/Visual%20Studio%20Code/VisualStudioCode.download.recipe) are Universal, so these arm64-specific VSCode recipes are redundant. I've marked them as deprecated and pointed anybody still using them to valdore86-recipes.