### PR TITLE
Make XMind8 download recipe runnable by default

### DIFF
--- a/XMind8/XMind8.download.recipe
+++ b/XMind8/XMind8.download.recipe
@@ -17,7 +17,7 @@
      For MAC OX use macosx
      For LINUX use linux -->
 		<key>OS</key>
-		<string></string>
+		<string>macosx</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
This PR adds a default value for the os input variable for the XMind8 download recipe. This will make it easier to test whether this recipe is working in the future, while not affecting users who have already created overrides with other os values.

Verbose recipe run output:

```
% autopkg run -vvq 'XMind8/XMind8.download.recipe'
Processing XMind8/XMind8.download.recipe...
WARNING: XMind8/XMind8.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_flags': ['IGNORECASE'],
           're_pattern': '//www.xmind.app/xmind/downloads/xmind-[0-9]*-([^"]*)-macosx.',
           'result_output_var_name': 'version',
           'url': 'https://www.xmind.app/download/xmind8/'}}
URLTextSearcher: Found matching text (version): update9
{'Output': {'version': 'update9'}}
URLTextSearcher
{'Input': {'re_flags': ['IGNORECASE'],
           're_pattern': '(//www.xmind.app/xmind/downloads/xmind-[0-9]*-update9-macosx.[a-zA-Z]*)',
           'result_output_var_name': 'url',
           'url': 'https://www.xmind.app/download/xmind8/'}}
URLTextSearcher: Found matching text (url): //www.xmind.app/xmind/downloads/xmind-8-update9-macosx.dmg
{'Output': {'url': '//www.xmind.app/xmind/downloads/xmind-8-update9-macosx.dmg'}}
URLDownloader
{'Input': {'url': 'https://www.xmind.app/xmind/downloads/xmind-8-update9-macosx.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2019 08:36:22 GMT
URLDownloader: Storing new ETag header: "d99ac6c023faac05c19c7c8a4a6850bf-11"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peshay.download.XMind8/downloads/xmind-8-update9-macosx.dmg
{'Output': {'download_changed': True,
            'etag': '"d99ac6c023faac05c19c7c8a4a6850bf-11"',
            'last_modified': 'Tue, 10 Dec 2019 08:36:22 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peshay.download.XMind8/downloads/xmind-8-update9-macosx.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.XMind8/downloads/xmind-8-update9-macosx.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peshay.download.XMind8/receipts/XMind8.download-receipt-20241227-200503.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.peshay.download.XMind8/downloads/xmind-8-update9-macosx.dmg
```

