### PR TITLE
Update download URL for X-Mirage and simplify download recipe

### DIFF
--- a/X-Mirage/X-Mirage.download.recipe
+++ b/X-Mirage/X-Mirage.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>X-Mirage</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://dl.x-mirage.com/x-mirage.dmg</string>
+		<string>https://x-mirage.com/download/x-mirage.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -31,39 +31,25 @@
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/Applications</string>
-			</dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
+			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/X-Mirage.app</string>
-				<key>source_path</key>
+				<key>input_path</key>
 				<string>%pathname%/X-Mirage.app</string>
+				<key>requirement</key>
+				<string>identifier "com.xidasoft.X-Mirage" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z4MR8KD2PQ</string>
 			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
 		</dict>
 		<dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%pkgroot%/X-Mirage.app/Contents/Info.plist</string>
-            </dict>
-        </dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pkgroot%/X-Mirage.app/Contents/Info.plist</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/X-Mirage/X-Mirage.filewave.recipe
+++ b/X-Mirage/X-Mirage.filewave.recipe
@@ -24,6 +24,31 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%pkgroot%/X-Mirage.app</string>
+				<key>source_path</key>
+				<string>%pathname%/X-Mirage.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
                 <key>fw_app_bundle_id</key>
 				<string>%fw_app_bundle_id%</string>
 				<key>fw_app_version</key>


### PR DESCRIPTION
This PR updates the download URL for X-Mirage, and moves Filewave-specific processors into the .filewave child recipe.

Verbose recipe run output:

```
% autopkg run -vvq 'X-Mirage/X-Mirage.download.recipe'
Processing X-Mirage/X-Mirage.download.recipe...
WARNING: X-Mirage/X-Mirage.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://x-mirage.com/download/x-mirage.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 22 Dec 2020 06:06:01 GMT
URLDownloader: Storing new ETag header: "32d8d3f-5b7075e760440"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg
{'Output': {'download_changed': True,
            'etag': '"32d8d3f-5b7075e760440"',
            'last_modified': 'Tue, 22 Dec 2020 06:06:01 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg/X-Mirage.app',
           'requirement': 'identifier "com.xidasoft.X-Mirage" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'Z4MR8KD2PQ'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Py6Ra7/X-Mirage.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Py6Ra7/X-Mirage.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Py6Ra7/X-Mirage.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications/X-Mirage.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg/X-Mirage.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg, dmg: .dmg/, dmg_source_path: X-Mirage.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg
Copier: Copied /private/tmp/dmg.xKI1No/X-Mirage.app to ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications/X-Mirage.app
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications/X-Mirage.app/Contents/Info.plist'}}
Versioner: No value supplied for plist_version_key, setting default value of: CFBundleShortVersionString
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 3.0.2 in file ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/Applications/X-Mirage.app/Contents/Info.plist
{'Output': {'version': '3.0.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/receipts/X-Mirage.download-receipt-20241227-200301.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.peshay.download.X-Mirage/downloads/x-mirage.dmg
```

