### PR TITLE
Deprecate Telegram recipes

### DIFF
--- a/Telegram/Telegram.download.recipe
+++ b/Telegram/Telegram.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Telegram recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional Telegram recipes in this repo, and points users to working equivalents in the tallfunnyjew-recipes repo.
