### PR TITLE
Clean up InstallDiskCreator recipes

### DIFF
--- a/InstallDiskCreator/InstallDiskCreator.download.recipe
+++ b/InstallDiskCreator/InstallDiskCreator.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the InstallDiskCreator recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>

--- a/InstallDiskCreator/InstallDiskCreator.filewave.recipe
+++ b/InstallDiskCreator/InstallDiskCreator.filewave.recipe
@@ -18,9 +18,20 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.peshay.download.InstallDiskCreator</string>
+	<string>com.github.ahousseini-recipes.download.InstallDiskCreator</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>FileMover</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Install Disk Creator.app</string>
+				<key>target</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/InstallDiskCreator.app</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR reduces redundancy in the recipes hosted on the AutoPkg org by deprecating the InstallDiskCreator download recipe in this repo and pointing users at the equivalent recipe in ahousseini-recipes.
