### PR TITLE
Fix DotNETProfiler.download and add ARCH input variable

### DIFF
--- a/YourKit/DotNETProfiler.download.recipe
+++ b/YourKit/DotNETProfiler.download.recipe
@@ -3,49 +3,43 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of DotNETProfiler.</string>
+	<string>Downloads the latest version of DotNETProfiler.
+	
+Valid ARCH values include:
+- x64
+- arm64
+</string>
 	<key>Identifier</key>
 	<string>com.github.peshay.download.DotNETProfiler</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>DotNETProfiler</string>
+		<key>ARCH</key>
+		<string>x64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
-        <dict>
-	    <key>Processor</key>
-	    <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://www.yourkit.com/.net/profiler/download/</string>
-                <key>result_output_var_name</key>
-                <string>version</string>
-                <key>re_pattern</key>
-                <string>href="\/dotnet\/download\/YourKit-NetProfiler-([0-9]+.[0-9]+)-[^"]*.exe</string>
-            </dict>
-	</dict>
-        <dict>
-	    <key>Processor</key>
-	    <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://www.yourkit.com/.net/profiler/download/</string>
-                <key>result_output_var_name</key>
-                <string>build</string>
-                <key>re_pattern</key>
-                <string>href="\/dotnet\/download\/YourKit-NetProfiler-%version%-([^"]*).exe</string>
-            </dict>
-	</dict>
-        <dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>href="https://download\.yourkit\.com/ynp/[\d\.]+/YourKit-NetProfiler-(?P&lt;version&gt;[\d\.]+)-(?P&lt;build&gt;[a-z\d]+)-%ARCH%\.exe"</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+				<key>url</key>
+				<string>https://www.yourkit.com/dotnet-profiler/download/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://www.yourkit.com/dotnet/download/YourKit-NetProfiler-%version%-%build%.exe</string>
+				<string>https://download.yourkit.com/ynp/2024.9/YourKit-NetProfiler-%version%-%build%-%ARCH%.exe</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR fixes the file pattern used to download DotNETProfiler, and adds an ARCH input variable for specifying which architecture version to download.

Verbose recipe run log:

```
% autopkg run -vvq 'YourKit/DotNETProfiler.download.recipe'
Processing YourKit/DotNETProfiler.download.recipe...
WARNING: YourKit/DotNETProfiler.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="https://download\\.yourkit\\.com/ynp/[\\d\\.]+/YourKit-NetProfiler-(?P<version>[\\d\\.]+)-(?P<build>[a-z\\d]+)-x64\\.exe"',
           'result_output_var_name': 'version',
           'url': 'https://www.yourkit.com/dotnet-profiler/download/'}}
URLTextSearcher: Found matching text (version): 2024.9
URLTextSearcher: Found matching text (build): b154
{'Output': {'build': 'b154', 'version': '2024.9'}}
URLDownloader
{'Input': {'url': 'https://download.yourkit.com/ynp/2024.9/YourKit-NetProfiler-2024.9-b154-x64.exe'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 19 Dec 2024 13:57:36 GMT
URLDownloader: Storing new ETag header: "67642650-6f24b90"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peshay.download.DotNETProfiler/downloads/YourKit-NetProfiler-2024.9-b154-x64.exe
{'Output': {'download_changed': True,
            'etag': '"67642650-6f24b90"',
            'last_modified': 'Thu, 19 Dec 2024 13:57:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peshay.download.DotNETProfiler/downloads/YourKit-NetProfiler-2024.9-b154-x64.exe',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.DotNETProfiler/downloads/YourKit-NetProfiler-2024.9-b154-x64.exe'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peshay.download.DotNETProfiler/receipts/DotNETProfiler.download-receipt-20241227-193100.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.peshay.download.DotNETProfiler/downloads/YourKit-NetProfiler-2024.9-b154-x64.exe
```
