### PR TITLE
Update file pattern and add code signature verification for DOSBox

### DIFF
--- a/DOSBox/DOSBox.download.recipe
+++ b/DOSBox/DOSBox.download.recipe
@@ -12,17 +12,17 @@
         <string>DOSBox</string>
         <key>os</key>
         <!--SELECT YOUR OS VERSION AND INPUT BELOW
-		"Mac OS X" for MAC OS X
-		"Windows" for WINDOWS EXE
-		"Fedora" for FEDORA LINUX
-		-->
+        "Mac OS X" for MAC OS X
+        "Windows" for WINDOWS EXE
+        "Fedora" for FEDORA LINUX
+        -->
         <string>Mac OS X</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>
     <key>Process</key>
     <array>
-    	<dict>
+        <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
@@ -30,7 +30,7 @@
                 <key>url</key>
                 <string>https://www.dosbox.com/download.php?main=1</string>
                 <key>re_pattern</key>
-                <string>href="(http://sourceforge.net/projects/dosbox/files/dosbox/[^"]*)" target="_blank">%os%</string>
+                <string>href="(https://sourceforge\.net/projects/dosbox/files/dosbox/[\d\.-]+/DOSBox-[\d\.-]+\.dmg/download)" target="_blank">%os%</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>
@@ -40,42 +40,57 @@
             </dict>
         </dict>
         <dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
                 <key>url</key>
                 <string>%url%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/Applications</string>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/DOSBox.app</string>
-				<key>source_path</key>
-				<string>%pathname%/*.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/DOSBox.app</string>
+                <key>requirement</key>
+                <string>identifier "com.dosbox.dosbox" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5PRK96AWD5"</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0775</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%pkgroot%/DOSBox.app</string>
+                <key>source_path</key>
+                <string>%pathname%/*.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
@@ -83,10 +98,6 @@
                 <key>input_plist_path</key>
                 <string>%pkgroot%/DOSBox.app/Contents/Info.plist</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This PR gets the DOSBox recipes back to working order by updating the file pattern and adding code signature verification.

Verbose recipe run output:

```
% autopkg run -vvq 'DOSBox/DOSBox.download.recipe'
Processing DOSBox/DOSBox.download.recipe...
WARNING: DOSBox/DOSBox.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_flags': ['IGNORECASE'],
           're_pattern': 'href="(https://sourceforge\\.net/projects/dosbox/files/dosbox/[\\d\\.-]+/DOSBox-[\\d\\.-]+\\.dmg/download)" '
                         'target="_blank">Mac OS X',
           'result_output_var_name': 'url',
           'url': 'https://www.dosbox.com/download.php?main=1'}}
URLTextSearcher: Found matching text (url): https://sourceforge.net/projects/dosbox/files/dosbox/0.74-3/DOSBox-0.74-3-3.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/dosbox/files/dosbox/0.74-3/DOSBox-0.74-3-3.dmg/download'}}
URLDownloader
{'Input': {'filename': 'DOSBox.dmg',
           'url': 'https://sourceforge.net/projects/dosbox/files/dosbox/0.74-3/DOSBox-0.74-3-3.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 22 Sep 2020 19:13:37 GMT
URLDownloader: Storing new ETag header: "5f6a4ce1-3fcc66"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg
{'Output': {'download_changed': True,
            'etag': '"5f6a4ce1-3fcc66"',
            'last_modified': 'Tue, 22 Sep 2020 19:13:37 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg/DOSBox.app',
           'requirement': 'identifier "com.dosbox.dosbox" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5PRK96AWD5"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.SRiaS4/DOSBox.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SRiaS4/DOSBox.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SRiaS4/DOSBox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications/DOSBox.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg/*.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg, dmg: .dmg/, dmg_source_path: *.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg
Copier: Using path '/private/tmp/dmg.9N7OqG/dosbox.app' matched from globbed '/private/tmp/dmg.9N7OqG/*.app'.
Copier: Copied /private/tmp/dmg.9N7OqG/dosbox.app to ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications/DOSBox.app
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications/DOSBox.app/Contents/Info.plist'}}
Versioner: No value supplied for plist_version_key, setting default value of: CFBundleShortVersionString
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version .74-3-3 in file ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/Applications/DOSBox.app/Contents/Info.plist
{'Output': {'version': '.74-3-3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/receipts/DOSBox.download-receipt-20241227-192416.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.peshay.download.DOSBox/downloads/DOSBox.dmg
```

