### PR TITLE
Make Cloudya recipes runnable by default

### DIFF
--- a/NFON/Cloudya.download.recipe
+++ b/NFON/Cloudya.download.recipe
@@ -3,7 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest version of Cloudya </string>
+	<string>Downloads latest version of Cloudya
+	
+Valid values for OS include:
+- "mac" (default, Cloudya without CRM Connect for macOS)
+- "crm-mac" (Cloudya with CRM Connect for macOS)
+- "win" (Cloudya without CRM Connect for Windows)
+- "crm-win" (Cloudya with CRM Connect for Windows)
+- "win-msi" (MSI for Cloudya without CRM Connect for Windows)
+- "crm-win-msi" (MSI Cloudya with CRM Connect for Windows)
+</string>
 	<key>Identifier</key>
 	<string>com.github.peshay.download.cloudya</string>
 	<key>Input</key>
@@ -11,7 +20,7 @@
 		<key>NAME</key>
 		<string>Cloudya</string>
 		<key>OS</key>
-		<string></string>
+		<string>mac</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
This PR updates the Cloudya download recipe to specify what values of OS can be used, and provides a default OS value of "mac" to make it easier to test whether the recipe is still working.

Verbose recipe run output:

```
% autopkg run -vvq 'NFON/Cloudya.download.recipe'
Processing NFON/Cloudya.download.recipe...
WARNING: NFON/Cloudya.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_flags': ['IGNORECASE'],
           're_pattern': '(https://cdn.cloudya.com/Cloudya-[0-9]+.[0-9]+.[0-9]+-mac.zip)',
           'result_output_var_name': 'URL',
           'url': 'https://www.nfon.com/en/service/downloads'}}
URLTextSearcher: Found matching text (URL): https://cdn.cloudya.com/cloudya-1.7.7-mac.zip
{'Output': {'URL': 'https://cdn.cloudya.com/cloudya-1.7.7-mac.zip'}}
URLTextSearcher
{'Input': {'re_flags': ['IGNORECASE'],
           're_pattern': 'https://cdn.cloudya.com/Cloudya-([0-9]+.[0-9]+.[0-9]+)-mac.zip',
           'result_output_var_name': 'version',
           'url': 'https://www.nfon.com/en/service/downloads'}}
URLTextSearcher: Found matching text (version): 1.7.7
{'Output': {'version': '1.7.7'}}
URLDownloader
{'Input': {'url': 'https://cdn.cloudya.com/cloudya-1.7.7-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 09 Jan 2024 09:24:25 GMT
URLDownloader: Storing new ETag header: "659d10c9-1c77d651"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/downloads/cloudya-1.7.7-mac.zip
{'Output': {'download_changed': True,
            'etag': '"659d10c9-1c77d651"',
            'last_modified': 'Tue, 09 Jan 2024 09:24:25 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/downloads/cloudya-1.7.7-mac.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/downloads/cloudya-1.7.7-mac.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename cloudya-1.7.7-mac.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/downloads/cloudya-1.7.7-mac.zip to ~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/Cloudya
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/receipts/Cloudya.download-receipt-20241227-191915.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.peshay.download.cloudya/downloads/cloudya-1.7.7-mac.zip
```