### PR TITLE
Make Bluefish.download runnable by default

### DIFF
--- a/Bluefish/Bluefish.download.recipe
+++ b/Bluefish/Bluefish.download.recipe
@@ -15,7 +15,7 @@
 	"win32" for WINDOWS 32 BIT EXE
 -->
 		<key>os</key>
-		<string></string>
+		<string>macosx</string>
 	</dict>
 	<key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
This PR adds a default value for the OS input variable in the Bluefish download recipe, to make it easier to check whether the recipe is still working.

Verbose recipe run output:

```
% autopkg run -vvq 'Bluefish/Bluefish.download.recipe'
Processing Bluefish/Bluefish.download.recipe...
WARNING: Bluefish/Bluefish.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_flags': ['IGNORECASE'],
           're_pattern': 'href="(?P<match>Bluefish-[^"]*[.exe|.dmg])"',
           'url': 'https://www.bennewitz.com/bluefish/stable/binaries/macosx/?C=M;O=D'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): Bluefish-2.2.16.dmg
{'Output': {'match': 'Bluefish-2.2.16.dmg'}}
URLDownloader
{'Input': {'url': 'http://www.bennewitz.com/bluefish/stable/binaries/macosx/Bluefish-2.2.16.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 22 Sep 2024 19:05:06 GMT
URLDownloader: Storing new ETag header: "198e844-622b9f34f73e2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peshay.download.Bluefish/downloads/Bluefish-2.2.16.dmg
{'Output': {'download_changed': True,
            'etag': '"198e844-622b9f34f73e2"',
            'last_modified': 'Sun, 22 Sep 2024 19:05:06 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peshay.download.Bluefish/downloads/Bluefish-2.2.16.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peshay.download.Bluefish/downloads/Bluefish-2.2.16.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peshay.download.Bluefish/receipts/Bluefish.download-receipt-20241227-191241.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.peshay.download.Bluefish/downloads/Bluefish-2.2.16.dmg
```

