### PR TITLE
Deprecate Eclipse IDE for Java

### DIFF
--- a/Eclipse/EclipseIDEJavaDev.download.recipe
+++ b/Eclipse/EclipseIDEJavaDev.download.recipe
@@ -15,9 +15,18 @@
         <string>aarch64</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Eclipse recipes in the homebysix-recipes repo, and specifying ECLIPSE_CODE "java" in your override. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the Eclipse IDE for Java recipes, and points users to the recipe in my homebysix-recipes repo that provides the same installer in a more configurable manner.