### PR TITLE
Remove duplicate processor key from Enpass.filewave

### DIFF
--- a/Enpass/Enpass.filewave.recipe
+++ b/Enpass/Enpass.filewave.recipe
@@ -20,8 +20,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>fw_app_bundle_id</key>


### PR DESCRIPTION
This PR removes an extra key from the Enpass.filewave recipe.