### PR TITLE
Add code signature verification for PingPlotter

### DIFF
--- a/PingPlotter/PingPlotter.download.recipe
+++ b/PingPlotter/PingPlotter.download.recipe
@@ -32,6 +32,17 @@
             <key>Processor</key>
             <string>Unarchiver</string>
     	</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/PingPlotter.app</string>
+				<key>requirement</key>
+				<string>identifier "com.pingman.pingplotter.mac" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JXB6F3JSYT</string>
+			</dict>
+		</dict>
     	<dict>
             <key>Processor</key>
             <string>Versioner</string>


### PR DESCRIPTION
This PR adds code signature verification to the PingPlotter recipes.

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peshay.download.PingPlotter/PingPlotter/PingPlotter.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peshay.download.PingPlotter/PingPlotter/PingPlotter.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peshay.download.PingPlotter/PingPlotter/PingPlotter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```
