### PR TITLE
Deprecate MenuMeters download recipe

### DIFF
--- a/RagingMenace/MenuMeters.download.recipe
+++ b/RagingMenace/MenuMeters.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of MenuMeters.</string> 
+	<string>Downloads the latest version of MenuMeters (yujitach).</string> 
 	<key>Identifier</key>
 	<string>com.github.peshay.download.MenuMeters</string>
 	<key>Input</key>
@@ -12,28 +12,37 @@
 		<string>MenuMeters</string>
 	</dict>
 	<key>MinimumVersion</key>
-    <string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
-        	<key>Arguments</key>
-        	<dict>
-          		<key>github_repo</key>
-          		<string>yujitach/MenuMeters</string>
-          		<key>asset_regex</key>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the MenuMeters (yujitach) recipes in the kevinmcox-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>github_repo</key>
+				<string>yujitach/MenuMeters</string>
+				<key>asset_regex</key>
 			<string>(MenuMeters_[^"]*.zip)</string>
-        	</dict>
-        		<key>Processor</key>
-        		<string>GitHubReleasesInfoProvider</string>
-      		</dict>
+			</dict>
+				<key>Processor</key>
+				<string>GitHubReleasesInfoProvider</string>
+			</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
-                        <key>Processor</key>
-                        <string>Unarchiver</string>
-                </dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>

--- a/RagingMenace/MenuMeters.filewave.recipe
+++ b/RagingMenace/MenuMeters.filewave.recipe
@@ -9,7 +9,7 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.peshay.download.MenuMeters</string>
+	<string>com.github.kevinmcox.download.MenuMeters</string>
     <key>Input</key>
 	<dict>
 		<key>NAME</key>


### PR DESCRIPTION
This PR deprecates the MenuMeters (yujitach) download recipe, which is redunandant with the recipes in the kevinmcox-recipes repo.
