### PR TITLE
Update DBeaverCE.download.recipe

### DIFF
--- a/DBeaverCE/DBeaverCE.download.recipe
+++ b/DBeaverCE/DBeaverCE.download.recipe
@@ -12,7 +12,6 @@
         <string>DBeaverCE</string>
         
 <!--SELECT YOUR OS VERSION AND USE IT IN YOUR OVERRIDE
-	"installer" for MAC OS X Pkg installer
 	"macos-x86_64" for macOS x86_64 DMG
 	"macos-aarch64" for macOS arm64 M1 DMG
 	"linux.gtk.x86" for LINUX 32bit


### PR DESCRIPTION
Remove reference to the package installer which was deprecated and no longer released starting with version 7.3.1 back in 2020.

https://github.com/dbeaver/dbeaver/releases/tag/7.3.1