### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Bluefish/Bluefish.download.recipe
+++ b/Bluefish/Bluefish.download.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
                 <key>url</key>
-                <string>http://www.bennewitz.com/bluefish/stable/binaries/%os%/%match%</string>
+                <string>https://www.bennewitz.com/bluefish/stable/binaries/%os%/%match%</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Oracle/JavaCryptographyExtension.download.recipe
+++ b/Oracle/JavaCryptographyExtension.download.recipe
@@ -36,7 +36,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.oracle.com/%url%</string>
+                <string>https://www.oracle.com/%url%</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>re_pattern</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._