### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/OpenJDK13/OpenJDK13.pkg.recipe
+++ b/OpenJDK13/OpenJDK13.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK15/OpenJDK15.pkg.recipe
+++ b/OpenJDK15/OpenJDK15.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK16/OpenJDK16.pkg.recipe
+++ b/OpenJDK16/OpenJDK16.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK17/OpenJDK17.pkg.recipe
+++ b/OpenJDK17/OpenJDK17.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK18/OpenJDK18.pkg.recipe
+++ b/OpenJDK18/OpenJDK18.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK19/OpenJDK19.pkg.recipe
+++ b/OpenJDK19/OpenJDK19.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK20/OpenJDK20.pkg.recipe
+++ b/OpenJDK20/OpenJDK20.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK21/OpenJDK21.pkg.recipe
+++ b/OpenJDK21/OpenJDK21.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/OpenJDK22/OpenJDK22.pkg.recipe
+++ b/OpenJDK22/OpenJDK22.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._